### PR TITLE
fix: 🐛 Correct `AgentGroupMembership.groupId` attribute name

### DIFF
--- a/src/mappings/entities/mapTickerExternalAgentHistory.ts
+++ b/src/mappings/entities/mapTickerExternalAgentHistory.ts
@@ -91,7 +91,7 @@ export async function mapTickerExternalAgentHistory(
         AgentGroupMembership.create({
           id: `${ticker}/${group.custom}/${did}`,
           member: did,
-          group: `${ticker}/${group.custom}`,
+          groupId: `${ticker}/${group.custom}`,
         }).save()
       );
     }
@@ -130,7 +130,7 @@ export async function mapTickerExternalAgentHistory(
         AgentGroupMembership.create({
           id: `${ticker}/${group.custom}/${did}`,
           member: did,
-          group: `${ticker}/${group.custom}`,
+          groupId: `${ticker}/${group.custom}`,
         }).save()
       );
     }


### PR DESCRIPTION
### Description

While create `AgentGroupMembership`, the attribute `groupId` was incorrectly referred to as `group` causing the following error 
```
ERROR:  null value in column "group_id" violates not-null constraint
```
This change corrects the name mismatch.

### JIRA Link

[DA-386](https://polymath.atlassian.net/browse/DA-386)

### Checklist

- [ ] Updated the Readme.md (if required) ?
