### PR TITLE
fix: 🐛 add_exempted_entities as enum

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1036,6 +1036,7 @@ enum CallIdEnum {
   redeem_from @deprecated
   reject_referendum @deprecated
   remove_active_rule @deprecated
+  add_exempted_entities @deprecated
   remove_exempted_entities @deprecated
   remove_primary_issuance_agent @deprecated
   remove_signing_keys @deprecated


### PR DESCRIPTION
### Description

Fixes the error: 

"ailed to index block at height 384889 handleCall() SequelizeDatabaseError: invalid input value for enum public_enum_0bf3c7d4ef: "add_exempted_entities"

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
