### PR TITLE
fix: 🐛 Correct parsing of address for secondary accounts and update Authorization entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1246,7 +1246,7 @@ type Authorization @entity {
   id: ID!
   type: AuthTypeEnum!
   from: Identity! @index(unique: false)
-  to: Identity @index(unique: false)
+  toId: String @index(unique: false)
   toKey: String @index(unique: false)
   data: String
   expiry: Date @index(unique: false)

--- a/scripts/diff_versions.ts
+++ b/scripts/diff_versions.ts
@@ -1,16 +1,10 @@
-import { load } from 'js-yaml';
-import { readFileSync, writeFileSync } from 'fs';
+import { writeFileSync } from 'fs';
 import { diff } from 'jest-diff';
 import { join } from 'path';
+import chainTypes from '../src/chainTypes';
 
-const project: any = load(
-  readFileSync(join(__dirname, '../project.template.yaml'), {
-    encoding: 'utf-8',
-  })
-);
-
-let versions: { minmax: [number, number]; types: Record<string, string> }[] =
-  project.network.typesBundle.spec.polymesh.types;
+let versions: { minmax: number[]; types: Record<string, string> }[] =
+  chainTypes.typesBundle.spec.polymesh.types;
 versions = versions.reverse();
 
 let previous = {};

--- a/spec_diffs/2021-2023
+++ b/spec_diffs/2021-2023
@@ -53,7 +53,7 @@
 -     },
 -   },
 -   "AssetMetadataLocalKey": "u64",
--   "AssetMetadataLockStatus<Moment>": Object {
+-   "AssetMetadataLockStatus": Object {
 -     "_enum": Object {
 -       "Locked": "",
 -       "LockedUntil": "Moment",
@@ -67,9 +67,9 @@
 -     "url": "Option<Url>",
 -   },
 -   "AssetMetadataValue": "Vec<u8>",
--   "AssetMetadataValueDetail<Moment>": Object {
+-   "AssetMetadataValueDetail": Object {
 -     "expire": "Option<Moment>",
--     "lock_status": "AssetMetadataLockStatus<Moment>",
+-     "lock_status": "AssetMetadataLockStatus",
 -   },
 -   "AssetName": "Text",
 -   "AssetOwnershipRelation": Object {
@@ -308,7 +308,7 @@
 -   "CompressedRistretto": "[u8; 32]",
 -   "Condition": Object {
 -     "condition_type": "ConditionType",
--     "issuers": "Vec<TrustedIssuer>",
+-     "issuers": "Vec<PolymeshPrimitivesConditionTrustedIssuer>",
 -   },
 -   "ConditionResult": Object {
 -     "condition": "Condition",
@@ -591,18 +591,7 @@
 -     "owner": "AccountId",
 -   },
 -   "DidRecord": Object {
--     "primary_key": "AccountId",
--     "secondary_keys": "Vec<SecondaryKey>",
--   },
--   "DidRecords": Object {
--     "_enum": Object {
--       "IdNotFound": "Vec<u8>",
--       "Success": "DidRecordsSuccess",
--     },
--   },
--   "DidRecordsSuccess": Object {
--     "primary_key": "AccountId",
--     "secondary_keys": "Vec<SecondaryKey>",
+-     "primary_key": "Option<AccountId>",
 -   },
 -   "DidStatus": Object {
 -     "_enum": Object {
@@ -778,6 +767,13 @@
 -   "KeyIdentityData": Object {
 -     "identity": "IdentityId",
 -     "permissions": "Option<Permissions>",
+-   },
+-   "KeyRecord": Object {
+-     "_enum": Object {
+-       "MultiSigSignerKey": "AccountId",
+-       "PrimaryKey": "IdentityId",
+-       "SecondaryKey": "(IdentityId, Permissions)",
+-     },
 -   },
 -   "Leg": Object {
 -     "amount": "Balance",
@@ -990,6 +986,16 @@
 -     ],
 -   },
 -   "RistrettoPoint": "[u8; 32]",
+-   "RpcDidRecords": Object {
+-     "_enum": Object {
+-       "IdNotFound": "Vec<u8>",
+-       "Success": "RpcDidRecordsSuccess",
+-     },
+-   },
+-   "RpcDidRecordsSuccess": Object {
+-     "primary_key": "AccountId",
+-     "secondary_keys": "Vec<SecondaryKey>",
+-   },
 -   "Scalar": "[u8; 32]",
 -   "ScheduleId": "u64",
 -   "ScheduleSpec": Object {
@@ -1011,11 +1017,11 @@
 -   },
 -   "ScopeId": "[u8; 32]",
 -   "SecondaryKey": Object {
+-     "key": "AccountId",
 -     "permissions": "Permissions",
--     "signer": "Signatory",
 -   },
 -   "SecondaryKeyWithAuth": Object {
--     "auth_signature": "Signature",
+-     "auth_signature": "H512",
 -     "secondary_key": "SecondaryKey",
 -   },
 -   "SecurityToken": Object {

--- a/spec_diffs/5000000-5000999
+++ b/spec_diffs/5000000-5000999
@@ -14,7 +14,7 @@
 +     },
 +   },
 +   "AssetMetadataLocalKey": "u64",
-+   "AssetMetadataLockStatus<Moment>": Object {
++   "AssetMetadataLockStatus": Object {
 +     "_enum": Object {
 +       "Locked": "",
 +       "LockedUntil": "Moment",
@@ -28,39 +28,41 @@
 +     "url": "Option<Url>",
 +   },
 +   "AssetMetadataValue": "Vec<u8>",
-+   "AssetMetadataValueDetail<Moment>": Object {
++   "AssetMetadataValueDetail": Object {
 +     "expire": "Option<Moment>",
-+     "lock_status": "AssetMetadataLockStatus<Moment>",
++     "lock_status": "AssetMetadataLockStatus",
 +   },
     "AssetName": "Text",
     "AssetOwnershipRelation": Object {
       "_enum": Object {
-@@ -54,8 +81,17 @@
-        "Except": "Vec<Ticker>",
+@@ -55,6 +82,15 @@
         "These": "Vec<Ticker>",
         "Whole": "",
-+     },
-    },
+      },
++   },
 +   "AssetScope": Object {
 +     "_enum": Object {
 +       "Ticker": "Ticker",
 +     },
-    },
++   },
 +   "AssetTransferCompliance": Object {
 +     "paused": "bool",
 +     "requirements": "Vec<TransferCondition>",
-+   },
+    },
     "AssetType": Object {
       "_enum": Object {
-        "Commodity": "",
-@@ -266,6 +302,7 @@
+@@ -266,9 +302,10 @@
       "result": "bool",
       "sender_conditions": "Vec<ConditionResult>",
     },
 +   "CompressedRistretto": "[u8; 32]",
     "Condition": Object {
       "condition_type": "ConditionType",
-      "issuers": "Vec<TrustedIssuer>",
+-     "issuers": "Vec<TrustedIssuer>",
++     "issuers": "Vec<PolymeshPrimitivesConditionTrustedIssuer>",
+    },
+    "ConditionResult": Object {
+      "condition": "Condition",
 @@ -291,7 +328,6 @@
       "targets": "TargetIdentities",
       "withholding_tax": "Vec<(IdentityId, Tax)>",
@@ -69,7 +71,27 @@
     "CountryCode": Object {
       "_enum": Array [
         "AF",
-@@ -673,7 +709,7 @@
+@@ -552,18 +588,7 @@
+      "owner": "AccountId",
+    },
+    "DidRecord": Object {
+-     "primary_key": "AccountId",
+-     "secondary_keys": "Vec<SecondaryKey>",
+-   },
+-   "DidRecords": Object {
+-     "_enum": Object {
+-       "IdNotFound": "Vec<u8>",
+-       "Success": "DidRecordsSuccess",
+-     },
+-   },
+-   "DidRecordsSuccess": Object {
+-     "primary_key": "AccountId",
+-     "secondary_keys": "Vec<SecondaryKey>",
++     "primary_key": "Option<AccountId>",
+    },
+    "DidStatus": Object {
+      "_enum": Object {
+@@ -673,7 +698,7 @@
       "self_transfer": "bool",
       "sender_custodian_error": "bool",
       "sender_insufficient_balance": "bool",
@@ -78,7 +100,7 @@
     },
     "HandledTxStatus": Object {
       "_enum": Object {
-@@ -726,7 +762,10 @@
+@@ -726,7 +751,10 @@
       },
     },
     "InvestorUid": "[u8; 16]",
@@ -90,7 +112,21 @@
     "ItnRewardStatus": Object {
       "_enum": Object {
         "Claimed": "",
-@@ -769,7 +808,7 @@
+@@ -737,6 +765,13 @@
+      "identity": "IdentityId",
+      "permissions": "Option<Permissions>",
+    },
++   "KeyRecord": Object {
++     "_enum": Object {
++       "MultiSigSignerKey": "AccountId",
++       "PrimaryKey": "IdentityId",
++       "SecondaryKey": "(IdentityId, Permissions)",
++     },
++   },
+    "Leg": Object {
+      "amount": "Balance",
+      "asset": "Ticker",
+@@ -769,7 +804,7 @@
         "Some": "BlockNumber",
       },
     },
@@ -99,26 +135,57 @@
     "MetaDescription": "Text",
     "MetaUrl": "Text",
     "MetaVersion": "u32",
-@@ -785,14 +824,8 @@
-      "amount": "Balance",
+@@ -786,13 +821,7 @@
       "memo": "Option<Memo>",
       "ticker": "Ticker",
--   },
+    },
 -   "OffChainSignature": Object {
 -     "_enum": Object {
 -       "Ecdsa": "H512",
 -       "Ed25519": "H512",
 -       "Sr25519": "H512",
 -     },
-    },
+-   },
 +   "OffChainSignature": "MultiSignature",
     "PalletName": "Text",
     "PalletPermissions": Object {
       "dispatchable_names": "DispatchableNames",
-@@ -1040,6 +1073,37 @@
+@@ -954,6 +983,16 @@
+      ],
+    },
+    "RistrettoPoint": "[u8; 32]",
++   "RpcDidRecords": Object {
++     "_enum": Object {
++       "IdNotFound": "Vec<u8>",
++       "Success": "RpcDidRecordsSuccess",
++     },
++   },
++   "RpcDidRecordsSuccess": Object {
++     "primary_key": "AccountId",
++     "secondary_keys": "Vec<SecondaryKey>",
++   },
+    "Scalar": "[u8; 32]",
+    "ScheduleId": "u64",
+    "ScheduleSpec": Object {
+@@ -975,11 +1014,11 @@
+    },
+    "ScopeId": "[u8; 32]",
+    "SecondaryKey": Object {
++     "key": "AccountId",
+      "permissions": "Permissions",
+-     "signer": "Signatory",
+    },
+    "SecondaryKeyWithAuth": Object {
+-     "auth_signature": "Signature",
++     "auth_signature": "H512",
+      "secondary_key": "SecondaryKey",
+    },
+    "SecurityToken": Object {
+@@ -1039,7 +1078,38 @@
+    "SnapshottedPip": Object {
       "id": "PipId",
       "weight": "(bool, Balance)",
-    },
++   },
 +   "Stat1stKey": Object {
 +     "asset": "AssetScope",
 +     "stat_type": "StatType",
@@ -145,7 +212,7 @@
 +   "StatType": Object {
 +     "claim_issuer": "Option<(ClaimType, IdentityId)>",
 +     "op": "StatOpType",
-+   },
+    },
 +   "StatUpdate": Object {
 +     "key2": "Stat2ndKey",
 +     "value": "Option<u128>",
@@ -153,7 +220,7 @@
     "StoredSchedule": Object {
       "at": "Moment",
       "id": "ScheduleId",
-@@ -1093,15 +1157,22 @@
+@@ -1093,15 +1163,22 @@
       "max_ticker_length": "u8",
       "registration_length": "Option<Moment>",
     },
@@ -166,14 +233,14 @@
 +       "ClaimOwnership": "(StatClaim, IdentityId, Percentage, Percentage)",
 +       "MaxInvestorCount": "u64",
 +       "MaxInvestorOwnership": "Percentage",
-      },
++     },
     },
--   "TransferManagerResult": Object {
 +   "TransferConditionExemptKey": Object {
 +     "asset": "AssetScope",
 +     "claim_type": "Option<ClaimType>",
 +     "op": "StatOpType",
-+   },
+    },
+-   "TransferManagerResult": Object {
 +   "TransferConditionResult": Object {
 +     "condition": "TransferCondition",
       "result": "bool",
@@ -181,7 +248,7 @@
     },
     "TrustedFor": Object {
       "_enum": Object {
-@@ -1153,6 +1224,12 @@
+@@ -1153,6 +1230,12 @@
       "ayes_stake": "Balance",
       "nays_count": "u32",
       "nays_stake": "Balance",

--- a/src/chainTypes/5.x.x.json
+++ b/src/chainTypes/5.x.x.json
@@ -75,12 +75,10 @@
   "AssetMetadataLocalKey": "u64",
   "AssetMetadataGlobalKey": "u64",
   "AssetMetadataKey": { "_enum": { "Global": "u64", "Local": "u64" } },
-  "AssetMetadataLockStatus<Moment>": {
-    "_enum": { "Unlocked": "", "Locked": "", "LockedUntil": "Moment" }
-  },
-  "AssetMetadataValueDetail<Moment>": {
+  "AssetMetadataLockStatus": { "_enum": { "Unlocked": "", "Locked": "", "LockedUntil": "Moment" } },
+  "AssetMetadataValueDetail": {
     "expire": "Option<Moment>",
-    "lock_status": "AssetMetadataLockStatus<Moment>"
+    "lock_status": "AssetMetadataLockStatus"
   },
   "AssetMetadataDescription": "Text",
   "AssetMetadataSpec": {
@@ -125,8 +123,8 @@
     "portfolio": "Option<Vec<PortfolioId>>"
   },
   "Signatory": { "_enum": { "Identity": "IdentityId", "Account": "AccountId" } },
-  "SecondaryKey": { "signer": "Signatory", "permissions": "Permissions" },
-  "SecondaryKeyWithAuth": { "secondary_key": "SecondaryKey", "auth_signature": "Signature" },
+  "SecondaryKey": { "key": "AccountId", "permissions": "Permissions" },
+  "SecondaryKeyWithAuth": { "secondary_key": "SecondaryKey", "auth_signature": "H512" },
   "Subsidy": { "paying_key": "AccountId", "remaining": "Balance" },
   "IdentityRole": {
     "_enum": [
@@ -143,7 +141,16 @@
     ]
   },
   "PreAuthorizedKeyInfo": { "target_id": "IdentityId", "secondary_key": "SecondaryKey" },
-  "DidRecord": { "primary_key": "AccountId", "secondary_keys": "Vec<SecondaryKey>" },
+  "DidRecord": {
+    "primary_key": "Option<AccountId>"
+  },
+  "KeyRecord": {
+    "_enum": {
+      "PrimaryKey": "IdentityId",
+      "SecondaryKey": "(IdentityId, Permissions)",
+      "MultiSigSignerKey": "AccountId"
+    }
+  },
   "KeyIdentityData": { "identity": "IdentityId", "permissions": "Option<Permissions>" },
   "CountryCode": {
     "_enum": [
@@ -477,7 +484,10 @@
   },
   "TrustedFor": { "_enum": { "Any": "", "Specific": "Vec<ClaimType>" } },
   "TrustedIssuer": { "issuer": "IdentityId", "trusted_for": "TrustedFor" },
-  "Condition": { "condition_type": "ConditionType", "issuers": "Vec<TrustedIssuer>" },
+  "Condition": {
+    "condition_type": "ConditionType",
+    "issuers": "Vec<PolymeshPrimitivesConditionTrustedIssuer>"
+  },
   "ConditionResult": { "condition": "Condition", "result": "bool" },
   "TargetIdAuthorization": { "target_id": "IdentityId", "nonce": "u64", "expires_at": "Moment" },
   "TickerRegistration": { "owner": "IdentityId", "expiry": "Option<Moment>" },
@@ -662,8 +672,8 @@
   },
   "CddStatus": { "_enum": { "Ok": "IdentityId", "Err": "Vec<u8>" } },
   "AssetDidResult": { "_enum": { "Ok": "IdentityId", "Err": "Vec<u8>" } },
-  "DidRecordsSuccess": { "primary_key": "AccountId", "secondary_keys": "Vec<SecondaryKey>" },
-  "DidRecords": { "_enum": { "Success": "DidRecordsSuccess", "IdNotFound": "Vec<u8>" } },
+  "RpcDidRecordsSuccess": { "primary_key": "AccountId", "secondary_keys": "Vec<SecondaryKey>" },
+  "RpcDidRecords": { "_enum": { "Success": "RpcDidRecordsSuccess", "IdNotFound": "Vec<u8>" } },
   "VoteCountProposalFound": { "ayes": "u64", "nays": "u64" },
   "VoteCount": {
     "_enum": { "ProposalFound": "VoteCountProposalFound", "ProposalNotFound": "" }

--- a/src/mappings/entities/mapIdentities.ts
+++ b/src/mappings/entities/mapIdentities.ts
@@ -185,9 +185,16 @@ const handleSecondaryKeysPermissionsUpdated = async (
 ): Promise<void> => {
   const [, rawSignerDetails, , rawUpdatedPermissions] = params;
 
-  const {
-    signer: { account: address },
-  } = JSON.parse(rawSignerDetails.toString());
+  let address;
+  try {
+    // for chain version < 5.0.0
+    ({
+      signer: { account: address },
+    } = JSON.parse(rawSignerDetails.toString()));
+  } catch (_) {
+    // for chain version >= 5.0.0
+    address = getTextValue(rawSignerDetails);
+  }
 
   const permissions = await Permissions.get(address);
   if (!permissions) {
@@ -246,7 +253,15 @@ const handleSecondaryKeysAdded = async (
 
   const promises = [];
 
-  accounts.forEach(({ signer: { account: address }, permissions }) => {
+  accounts.forEach(({ permissions, ...rest }) => {
+    let address;
+    if ('key' in rest) {
+      // for chain version >= 5.0.0
+      address = rest.key;
+    } else if ('signer' in rest) {
+      // for chain version < 5.0.0
+      address = rest.signer.account;
+    }
     const { assets, portfolios, transactions, transactionGroups } = getPermissions(permissions);
 
     promises.push(

--- a/src/mappings/entities/mapIdentities.ts
+++ b/src/mappings/entities/mapIdentities.ts
@@ -186,12 +186,11 @@ const handleSecondaryKeysPermissionsUpdated = async (
   const [, rawSignerDetails, , rawUpdatedPermissions] = params;
 
   let address;
-  try {
+  if (rawSignerDetails instanceof Map) {
     // for chain version < 5.0.0
-    ({
-      signer: { account: address },
-    } = JSON.parse(rawSignerDetails.toString()));
-  } catch (_) {
+    const signer = rawSignerDetails.get('signer').toString();
+    address = JSON.parse(signer).account;
+  } else {
     // for chain version >= 5.0.0
     address = getTextValue(rawSignerDetails);
   }


### PR DESCRIPTION
### Description

* Schema for secondary keys was changed for 5.x.x chain due to which block #925160 was failing in staging. 
`signer: Signatory` is replaced by `key: AccountId`

* Fixed the `diff_versions` script and updated them

* Replaced `to: Identity` to `toId: String` in `Authorization` schema

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
