### PR TITLE
chore: 🤖 Support unvalidated DID while creating legs

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1160,14 +1160,16 @@ type Account @entity {
   updatedBlock: Block!
 }
 
+# Identity will have null values for `primaryAccount`, `eventId`, `datetime` in cases where Identity is referenced without actually being created as in Authorization/Instruction
+# Once Identity is created, values will be updated for these attributes
 type Identity @entity {
   id: ID!
   did: String! @index(unique: true)
-  primaryAccount: String! @index(unique: false)
+  primaryAccount: String @index(unique: false)
   secondaryAccounts: [Account!]! @derivedFrom(field: "identity")
   secondaryKeysFrozen: Boolean!
-  eventId: EventIdEnum!
-  datetime: Date!
+  eventId: EventIdEnum
+  datetime: Date
   createdBlock: Block!
   updatedBlock: Block!
   heldAssets: [AssetHolder]! @derivedFrom(field: "identity")
@@ -1313,6 +1315,7 @@ type PortfolioJson @jsonField {
   number: Int!
 }
 
+# For each entry in DID, a default Portfolio (which contains number as 0) entry is created.
 type Portfolio @entity {
   id: ID! # did/number
   identity: Identity! @index(unique: false)

--- a/schema.graphql
+++ b/schema.graphql
@@ -1160,8 +1160,6 @@ type Account @entity {
   updatedBlock: Block!
 }
 
-# Identity will have null values for `primaryAccount`, `eventId`, `datetime` in cases where Identity is referenced without actually being created as in Authorization/Instruction
-# Once Identity is created, values will be updated for these attributes
 type Identity @entity {
   id: ID!
   did: String! @index(unique: true)
@@ -1315,7 +1313,7 @@ type PortfolioJson @jsonField {
   number: Int!
 }
 
-# For each entry in DID, a default Portfolio (which contains number as 0) entry is created.
+# For each entry in `Identity`, a default Portfolio (which contains number as 0) entry is created.
 type Portfolio @entity {
   id: ID! # did/number
   identity: Identity! @index(unique: false)

--- a/schema.graphql
+++ b/schema.graphql
@@ -1165,11 +1165,11 @@ type Account @entity {
 type Identity @entity {
   id: ID!
   did: String! @index(unique: true)
-  primaryAccount: String @index(unique: false)
+  primaryAccount: String! @index(unique: false)
   secondaryAccounts: [Account!]! @derivedFrom(field: "identity")
   secondaryKeysFrozen: Boolean!
-  eventId: EventIdEnum
-  datetime: Date
+  eventId: EventIdEnum!
+  datetime: Date!
   createdBlock: Block!
   updatedBlock: Block!
   heldAssets: [AssetHolder]! @derivedFrom(field: "identity")

--- a/src/mappings/entities/mapCompliance.ts
+++ b/src/mappings/entities/mapCompliance.ts
@@ -52,8 +52,6 @@ const handleComplianceReplaced = async (blockId: string, params: Codec[]) => {
 
   const existingCompliances = await Compliance.getByAssetId(ticker);
 
-  logger.info(JSON.stringify(rawCompliances.toJSON()));
-
   const compliances = getComplianceValues(rawCompliances);
 
   await Promise.all([

--- a/src/mappings/entities/mapIdentities.ts
+++ b/src/mappings/entities/mapIdentities.ts
@@ -108,7 +108,7 @@ const handleDidCreated = async (
   const address = getTextValue(rawAddress);
 
   let defaultPortfolio;
-  let identity = await Identity.get(did);
+  const identity = await Identity.get(did);
   if (identity) {
     Object.assign(identity, {
       primaryAccount: address,
@@ -116,12 +116,13 @@ const handleDidCreated = async (
       eventId,
       datetime,
     });
+    await identity.save();
 
     const portfolio = await getPortfolio({ identityId: did, number: 0 });
     portfolio.updatedBlockId = blockId;
     defaultPortfolio = portfolio.save();
   } else {
-    identity = Identity.create({
+    await Identity.create({
       id: did,
       did,
       primaryAccount: address,
@@ -130,7 +131,7 @@ const handleDidCreated = async (
       createdBlockId: blockId,
       updatedBlockId: blockId,
       datetime,
-    });
+    }).save();
 
     defaultPortfolio = createPortfolio(
       {
@@ -164,7 +165,7 @@ const handleDidCreated = async (
     datetime,
   }).save();
 
-  await Promise.all([identity.save(), permissions, account, defaultPortfolio]);
+  await Promise.all([permissions, account, defaultPortfolio]);
 };
 
 const getPermissions = (

--- a/src/mappings/entities/mapIdentities.ts
+++ b/src/mappings/entities/mapIdentities.ts
@@ -69,6 +69,9 @@ const getIdentity = async (did: string): Promise<Identity> => {
 
 /**
  * Creates an Identity if already not present. It also creates default Portfolio for that Identity
+ *
+ * @note WARNING: This function should only be used for the events that do not validate a DID to exists, before execution of the underlying extrinsic.
+ * For e.g. `settlement.InstructionCreated` as it doesn't validates the target DID
  */
 export const createIdentityIfNotExists = async (
   did: string,

--- a/src/mappings/entities/mapPortfolio.ts
+++ b/src/mappings/entities/mapPortfolio.ts
@@ -10,6 +10,7 @@ import {
   serializeTicker,
 } from '../util';
 import { Attributes, HandlerArgs } from './common';
+import { createIdentityIfNotExists } from './mapIdentities';
 
 export const getPortfolio = async ({
   identityId,
@@ -39,6 +40,30 @@ export const createPortfolio = (
   }).save();
 };
 
+/**
+ * Creates a Portfolio if not present.
+ * This can be need in case where someone creates an Instruction before the recipient Portfolio is created
+ */
+export const createPortfolioIfNotExists = async (
+  { identityId, number }: Pick<Portfolio, 'identityId' | 'number'>,
+  blockId: string,
+  event: SubstrateEvent
+): Promise<void> => {
+  await createIdentityIfNotExists(identityId, blockId, event);
+
+  if (number) {
+    await createPortfolio(
+      {
+        identityId,
+        number,
+        name: '',
+        eventIdx: event.idx,
+      },
+      blockId
+    );
+  }
+};
+
 const handlePortfolioCreated = async (
   blockId: string,
   params: Codec[],
@@ -50,15 +75,26 @@ const handlePortfolioCreated = async (
   const number = getNumberValue(rawPortfolioNumber);
   const name = getTextValue(rawName);
 
-  await createPortfolio(
-    {
-      identityId: ownerId,
-      number,
+  const portfolio = await Portfolio.get(`${ownerId}/${number}`);
+  if (!portfolio) {
+    await createPortfolio(
+      {
+        identityId: ownerId,
+        number,
+        name,
+        eventIdx,
+      },
+      blockId
+    );
+  } else {
+    Object.assign(portfolio, {
       name,
       eventIdx,
-    },
-    blockId
-  );
+      updatedBlockId: blockId,
+    });
+
+    await portfolio.save();
+  }
 };
 
 const handlePortfolioRenamed = async (blockId: string, params: Codec[]): Promise<void> => {

--- a/src/mappings/entities/mapPortfolio.ts
+++ b/src/mappings/entities/mapPortfolio.ts
@@ -42,7 +42,8 @@ export const createPortfolio = (
 
 /**
  * Creates a Portfolio if not present.
- * This can be need in case where someone creates an Instruction before the recipient Portfolio is created
+ *
+ * @note - WARNING: This is needed when an Instruction is created with a target Portfolio that doesn't exist. It should not be used unless necessary.
  */
 export const createPortfolioIfNotExists = async (
   { identityId, number }: Pick<Portfolio, 'identityId' | 'number'>,
@@ -51,7 +52,8 @@ export const createPortfolioIfNotExists = async (
 ): Promise<void> => {
   await createIdentityIfNotExists(identityId, blockId, event);
 
-  if (number) {
+  const portfolio = await Portfolio.get(`${identityId}/${number}`);
+  if (!portfolio) {
     await createPortfolio(
       {
         identityId,

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -206,7 +206,7 @@ export async function handleEvent(event: SubstrateEvent): Promise<void> {
     await Promise.all(handlerPromises);
   } catch (error) {
     logError(
-      `Received an error in handleEvent function: ${error} while handling the event '${moduleId}.${eventId}'`
+      `Received an error in handleEvent while handling the event '${moduleId}.${eventId}': ${error.stack}`
     );
     throw error;
   }

--- a/src/mappings/util.ts
+++ b/src/mappings/util.ts
@@ -220,10 +220,12 @@ export const getSecurityIdentifiers = (item: Codec): SecurityIdentifier[] => {
 /**
  * Parses a Vec<AssetCompliance>
  */
-export const getComplianceRulesValue = (
+export const getComplianceValues = (
   requirements: Codec
 ): Pick<Compliance, 'complianceId' | 'data'>[] => {
-  return JSON.parse(JSON.stringify(requirements));
+  const compliances = JSON.parse(requirements.toString());
+
+  return compliances.map(({ id, ...data }) => ({ complianceId: Number(id), data }));
 };
 
 /**


### PR DESCRIPTION
### Description

* While creating instructions, receiver DID/Portfolio isn't validated. To support this scenario, SQ inserts apt portfolio which isn't present (without any name). For this if the underlying DID is also not present, it creates one without any primaryAccount(sets the value to `''`). 
This was found in mainnet block - [1375280](https://polymesh.subscan.io/block/1375280?tab=event)

* Fix parsing of Asset compliances for `AssetComplianceReplaced` event.

### Breaking Changes

N/A

### JIRA Link

[DA-253](https://polymath.atlassian.net/browse/DA-253)

### Checklist

- [ ] Updated the Readme.md (if required) ?
