### PR TITLE
fix: 🐛 Handle ticker serialization with metadata v14

### DIFF
--- a/src/mappings/entities/mapExternalAgentAction.ts
+++ b/src/mappings/entities/mapExternalAgentAction.ts
@@ -1,6 +1,6 @@
 import { Codec } from '@polkadot/types/types';
 import { EventIdEnum, ModuleIdEnum, Sto, TickerExternalAgentAction } from '../../types';
-import { getOrDefault, getTextValue, serializeTicker } from '../util';
+import { getOfferingAsset, getOrDefault, getTextValue, serializeTicker } from '../util';
 import { HandlerArgs } from './common';
 
 /**
@@ -225,12 +225,7 @@ class ExternalAgentEventsManager {
       // Special case for the Sto pallet because most events don't contain the ticker,
       // they contain a reference to a previously created fundraiser instead.
       .add(ModuleIdEnum.sto, [EventIdEnum.FundraiserCreated], async params => {
-        const offeringAsset =
-          params[3] instanceof Map ? params[3].get('offering_asset') : undefined;
-        if (!offeringAsset) {
-          throw new Error("Couldn't find offeringAsset for sto");
-        }
-        return serializeTicker(offeringAsset);
+        return getOfferingAsset(params[3]);
       })
       .add(
         ModuleIdEnum.sto,

--- a/src/mappings/entities/mapSto.ts
+++ b/src/mappings/entities/mapSto.ts
@@ -1,5 +1,5 @@
 import { EventIdEnum, ModuleIdEnum, Sto } from '../../types';
-import { getTextValue, serializeTicker } from '../util';
+import { getOfferingAsset, getTextValue } from '../util';
 import { HandlerArgs } from './common';
 
 /**
@@ -7,13 +7,12 @@ import { HandlerArgs } from './common';
  */
 export async function mapSto({ blockId, eventId, moduleId, params }: HandlerArgs): Promise<void> {
   if (moduleId === ModuleIdEnum.sto && eventId === EventIdEnum.FundraiserCreated) {
-    const offeringAsset = params[3] instanceof Map ? params[3].get('offering_asset') : undefined;
-    if (!offeringAsset) {
-      throw new Error("Couldn't find offeringAsset for sto");
-    }
+    const [, rawStoId, , rawFundraiser] = params;
+    const offeringAssetId = getOfferingAsset(rawFundraiser);
+
     await Sto.create({
-      id: getTextValue(params[1]),
-      offeringAssetId: serializeTicker(offeringAsset),
+      id: getTextValue(rawStoId),
+      offeringAssetId,
       createdBlockId: blockId,
       updatedBlockId: blockId,
     }).save();

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -105,9 +105,21 @@ export async function handleToolingEvent(event: SubstrateEvent): Promise<void> {
   const eventId = event.event.method;
   const args = event.event.data.toArray();
 
-  const harvesterLikeArgs = args.map((arg, i) => ({
-    value: serializeLikeHarvester(arg, event.event.meta.args[i].toString(), logFoundType),
-  }));
+  const harvesterLikeArgs = args.map((arg, i) => {
+    let type;
+    const typeName = event.event.meta.fields[i].typeName;
+    if (typeName.isSome) {
+      // for metadata >= v14
+      type = typeName.unwrap().toString();
+    } else {
+      // for metadata < v14
+      type = event.event.meta.args[i].toString();
+    }
+    return {
+      value: serializeLikeHarvester(arg, type, logFoundType),
+    };
+  });
+
   const { eventArg_0, eventArg_1, eventArg_2, eventArg_3 } = extractEventArgs(harvesterLikeArgs);
 
   const { claimExpiry, claimIssuer, claimScope, claimType } = extractClaimInfo(harvesterLikeArgs);

--- a/src/mappings/util.ts
+++ b/src/mappings/util.ts
@@ -372,3 +372,8 @@ export const getDistributionValue = (
 export const logError = (message: string): void => {
   logger.error(message);
 };
+
+export const getOfferingAsset = (item: Codec): string => {
+  const fundraiser = JSON.parse(item.toString());
+  return hexToString(extractValue(fundraiser, 'offering_asset'));
+};


### PR DESCRIPTION
### Description

#### Problem 

With latest SQ sync, ticker values are not properly serialized and are getting stored in hex format.

#### Changelog

- The `serializeLikeHarvester` function wasn't able to return the serialized values for tickers since the meta-type was being received as `[u8;12]` instead of `Ticker`. To get the exact type name, `meta.fields` is now being used.
- Fixed the parsing issue of `offering_asset` for `sto.FundraiserCreated` event. [Staging block - [1765423](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fstaging-rpc.polymesh.live#/explorer/query/1765423)]
- Handles missing `fromId` for `Authorization` when `identity.cdd_register_did` is invoked. This particular case occurs
 when secondary keys are also passed as params along with target account. [Mainnet block - [2277507](https://polymesh.subscan.io/block/2277507)]

### Breaking Changes

NA

### JIRA Link

[DA-253](https://polymath.atlassian.net/browse/DA-253)

### Checklist

- [ ] Updated the Readme.md (if required) ?
