### PR TITLE
fix: 🐛 Handle identity state when claim added

### DIFF
--- a/src/mappings/entities/mapClaim.ts
+++ b/src/mappings/entities/mapClaim.ts
@@ -9,6 +9,7 @@ import {
 } from '../../types';
 import { END_OF_TIME, getTextValue, serializeTicker } from '../util';
 import { HandlerArgs } from './common';
+import { createIdentityIfNotExists } from './mapIdentities';
 
 interface ClaimParams {
   claimExpiry: bigint | undefined;
@@ -93,6 +94,9 @@ const handleClaimAdded = async (
   const scope = JSON.parse(claimScope) as Scope;
 
   const filterExpiry = claimExpiry || END_OF_TIME;
+
+  // The `target` for any claim is not validated, so we make sure it is present in `identities` table
+  await createIdentityIfNotExists(target, blockId, event);
 
   await Claim.create({
     id: getId(target, claimType, scope, jurisdiction, cddId),


### PR DESCRIPTION
### Description

With testnet block [1746733](https://polymesh-testnet.subscan.io/block/1746733?tab=event), claim added event was triggered with a non-existing target DID. Since the target claim isn't validated before depositing the event, this PR adds a check to make sure the identity exists.

### Breaking Changes

NA

### JIRA Link

DA-253

### Checklist

- [ ] Updated the Readme.md (if required) ?
