### PR TITLE
fix: 🐛 Testnet native graphql sync issues

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1321,6 +1321,7 @@ type Portfolio @entity {
   name: String
   custodian: Identity
   eventIdx: Int!
+  deletedAt: Date
   createdBlock: Block!
   updatedBlock: Block!
 }

--- a/src/mappings/entities/mapBridgeEvent.ts
+++ b/src/mappings/entities/mapBridgeEvent.ts
@@ -1,4 +1,5 @@
 import { BridgeEvent, EventIdEnum, ModuleIdEnum } from '../../types';
+import { extractString } from '../generatedColumns';
 import { getTextValue } from '../util';
 import { HandlerArgs } from './common';
 
@@ -15,14 +16,14 @@ export async function mapBridgeEvent({
   if (moduleId === ModuleIdEnum.bridge && eventId === EventIdEnum.Bridged) {
     const [rawDid, rawBridgeDetails] = params;
 
-    const { recipient, amount, tx_hash: txHash } = JSON.parse(rawBridgeDetails.toString());
+    const { recipient, amount, ...rest } = JSON.parse(rawBridgeDetails.toString());
 
     await BridgeEvent.create({
       id: `${blockId}/${event.idx}`,
       identityId: getTextValue(rawDid),
       recipient,
       amount: BigInt(amount) / BigInt(1000000),
-      txHash,
+      txHash: extractString(rest, 'tx_hash'),
       eventIdx: event.idx,
       datetime: event.block.timestamp,
       createdBlockId: blockId,

--- a/tests/entities/portfolios.test.ts
+++ b/tests/entities/portfolios.test.ts
@@ -9,6 +9,7 @@ describe('portfolios', () => {
         query {
           portfolios(
             filter: {
+              deletedAt: { isNull: true }
               identityId: {
                 equalTo: "0xc5e2d554233da63d509ee482dbeed0ddec94dc1d0b45ebfdcdc48bd0928222b1"
               }
@@ -40,6 +41,7 @@ describe('portfolios', () => {
         query {
           portfolios(
             filter: {
+              deletedAt: { isNull: true }
               identityId: {
                 equalTo: "0xc5e2d554233da63d509ee482dbeed0ddec94dc1d0b45ebfdcdc48bd0928222b1"
               }


### PR DESCRIPTION

### Description

Adds a `deletedAt` attribute to `Portfolio` entity which now gets populated when a portfolio is deleted, instead of removing the entity. This is to prevent the deletion of all other entities referencing the deleted Portfolio

### JIRA Link

DA-253

### Checklist

- [ ] Updated the Readme.md (if required) ?
