### PR TITLE
Changes to support chain 5.1.0 new features

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1339,6 +1339,7 @@ type PortfolioMovement @entity {
   to: Portfolio! @index(unique: false)
   asset: Asset!
   amount: BigInt!
+  memo: String
   address: String!
   createdBlock: Block!
   updatedBlock: Block!

--- a/src/mappings/entities/mapAsset.ts
+++ b/src/mappings/entities/mapAsset.ts
@@ -1,6 +1,14 @@
 import { Codec } from '@polkadot/types/types';
 import { SubstrateEvent } from '@subql/types';
-import { Asset, AssetDocument, AssetHolder, EventIdEnum, Funding, ModuleIdEnum } from '../../types';
+import {
+  Asset,
+  AssetDocument,
+  AssetHolder,
+  EventIdEnum,
+  Funding,
+  ModuleIdEnum,
+  SecurityIdentifier,
+} from '../../types';
 import {
   bytesToString,
   getBigIntValue,
@@ -79,8 +87,16 @@ const handleAssetCreated = async (
   const rawName = rawAssetName ?? (await api.query.asset.assetNames(rawTicker));
   const name = bytesToString(rawName);
 
-  const fundingRound = bytesToString(rawFundingRound);
-  const identifiers = getSecurityIdentifiers(rawIdentifiers);
+  // fundingRound and identifiers are emitted from chain >= 5.1.0
+  let fundingRound: string = null;
+  if (rawFundingRound) {
+    fundingRound = bytesToString(rawFundingRound);
+  }
+
+  let identifiers: SecurityIdentifier[] = [];
+  if (rawIdentifiers) {
+    identifiers = getSecurityIdentifiers(rawIdentifiers);
+  }
 
   await Asset.create({
     id: ticker,

--- a/src/mappings/entities/mapPortfolio.ts
+++ b/src/mappings/entities/mapPortfolio.ts
@@ -2,6 +2,7 @@ import { Codec } from '@polkadot/types/types';
 import { SubstrateEvent } from '@subql/types';
 import { EventIdEnum, ModuleIdEnum, Portfolio, PortfolioMovement } from '../../types';
 import {
+  bytesToString,
   getBigIntValue,
   getNumberValue,
   getPortfolioValue,
@@ -75,7 +76,7 @@ const handlePortfolioCreated = async (
 
   const ownerId = getTextValue(rawOwnerDid);
   const number = getNumberValue(rawPortfolioNumber);
-  const name = getTextValue(rawName);
+  const name = bytesToString(rawName);
 
   const portfolio = await Portfolio.get(`${ownerId}/${number}`);
   if (!portfolio) {
@@ -104,7 +105,7 @@ const handlePortfolioRenamed = async (blockId: string, params: Codec[]): Promise
 
   const ownerId = getTextValue(rawOwnerDid);
   const number = getNumberValue(rawPortfolioNumber);
-  const name = getTextValue(rawName);
+  const name = bytesToString(rawName);
 
   const portfolio = await getPortfolio({ identityId: ownerId, number });
   portfolio.name = name;
@@ -148,12 +149,13 @@ const handlePortfolioMovement = async (
   params: Codec[],
   event: SubstrateEvent
 ): Promise<void> => {
-  const [, rawFromPortfolio, rawToPortfolio, rawTicker, rawAmount] = params;
+  const [, rawFromPortfolio, rawToPortfolio, rawTicker, rawAmount, rawMemo] = params;
   const address = getSignerAddress(event);
   const from = getPortfolioValue(rawFromPortfolio);
   const to = getPortfolioValue(rawToPortfolio);
   const ticker = serializeTicker(rawTicker);
   const amount = getBigIntValue(rawAmount);
+  const memo = bytesToString(rawMemo);
 
   await PortfolioMovement.create({
     id: `${blockId}/${event.idx}`,
@@ -162,6 +164,7 @@ const handlePortfolioMovement = async (
     assetId: ticker,
     amount,
     address,
+    memo,
     createdBlockId: blockId,
     updatedBlockId: blockId,
   }).save();

--- a/src/mappings/entities/mapProposal.ts
+++ b/src/mappings/entities/mapProposal.ts
@@ -1,6 +1,7 @@
 import { Codec } from '@polkadot/types/types';
 import { EventIdEnum, ModuleIdEnum, Proposal, ProposalStateEnum, ProposalVote } from '../../types';
 import {
+  bytesToString,
   getBigIntValue,
   getBooleanValue,
   getFirstValueFromJson,
@@ -18,8 +19,8 @@ const handleProposalCreated = async (blockId: string, params: Codec[]): Promise<
     ownerId: getTextValue(rawDid),
     state: ProposalStateEnum.Pending,
     balance: getBigIntValue(rawBalance),
-    url: getTextValue(rawUrl),
-    description: getTextValue(rawDescription),
+    url: bytesToString(rawUrl),
+    description: bytesToString(rawDescription),
     snapshotted: false,
     totalAyeWeight: BigInt(0),
     totalNayWeight: BigInt(0),

--- a/src/mappings/entities/mapSettlement.ts
+++ b/src/mappings/entities/mapSettlement.ts
@@ -11,6 +11,7 @@ import {
   Venue,
 } from '../../types';
 import {
+  bytesToString,
   getDateValue,
   getFirstKeyFromJson,
   getFirstValueFromJson,
@@ -111,7 +112,7 @@ const handleVenueCreated = async (blockId: string, params: Codec[]): Promise<voi
   await Venue.create({
     id: getTextValue(rawVenueId),
     ownerId: getTextValue(rawIdentity),
-    details: getTextValue(rawDetails),
+    details: bytesToString(rawDetails),
     type: getTextValue(rawType),
     createdBlockId: blockId,
     updatedBlockId: blockId,
@@ -122,7 +123,7 @@ const handleVenueDetailsUpdated = async (blockId: string, params: Codec[]): Prom
   const [, rawVenueId, rawDetails] = params;
 
   const venue = await getVenue(getTextValue(rawVenueId));
-  venue.details = getTextValue(rawDetails);
+  venue.details = bytesToString(rawDetails);
   venue.updatedBlockId = blockId;
 
   await venue.save();
@@ -159,7 +160,7 @@ const handleInstructionCreated = async (
 
   const legs = getLegsValue(rawLegs);
   const instructionId = getTextValue(rawInstructionId);
-  const memo = getTextValue(rawOptMemo);
+  const memo = bytesToString(rawOptMemo);
 
   const instruction = Instruction.create({
     id: instructionId,

--- a/src/mappings/util.ts
+++ b/src/mappings/util.ts
@@ -1,6 +1,6 @@
 import { decodeAddress } from '@polkadot/keyring';
 import { Codec } from '@polkadot/types/types';
-import { hexHasPrefix, hexStripPrefix, u8aToHex, u8aToString } from '@polkadot/util';
+import { hexHasPrefix, hexStripPrefix, isHex, u8aToHex, u8aToString } from '@polkadot/util';
 import { SubstrateEvent, SubstrateExtrinsic } from '@subql/types';
 import { Portfolio } from 'polymesh-subql/types/models/Portfolio';
 import {
@@ -376,4 +376,12 @@ export const logError = (message: string): void => {
 export const getOfferingAsset = (item: Codec): string => {
   const fundraiser = JSON.parse(item.toString());
   return hexToString(extractValue(fundraiser, 'offering_asset'));
+};
+
+export const bytesToString = (item: Codec): string => {
+  const value = getTextValue(item);
+  if (isHex(value)) {
+    return hexToString(value);
+  }
+  return removeNullChars(value);
 };

--- a/tests/entities/__snapshots__/assets.test.ts.snap
+++ b/tests/entities/__snapshots__/assets.test.ts.snap
@@ -219,6 +219,51 @@ Object {
         },
         "type": "EquityCommon",
       },
+      Object {
+        "__typename": "Asset",
+        "compliance": Object {
+          "__typename": "CompliancesConnection",
+          "nodes": Array [
+            Object {
+              "__typename": "Compliance",
+              "data": "{\\"sender_conditions\\":[],\\"receiver_conditions\\":[]}",
+              "id": 1,
+            },
+          ],
+        },
+        "documents": Object {
+          "__typename": "AssetDocumentsConnection",
+          "nodes": Array [],
+        },
+        "fundingRound": "first",
+        "holders": Object {
+          "__typename": "AssetHoldersConnection",
+          "nodes": Array [
+            Object {
+              "__typename": "AssetHolder",
+              "amount": "1000100",
+              "did": "0xd7a5d0a364f335632cbbb59bb5615c12286f5b7298f6ddd58b584a6c08734538",
+            },
+          ],
+        },
+        "id": "8TICKER",
+        "identifiers": Array [],
+        "isCompliancePaused": false,
+        "isDivisible": true,
+        "isFrozen": false,
+        "isUniquenessRequired": false,
+        "name": "8TICKER",
+        "nodeId": "WyJhc3NldHMiLCI4VElDS0VSIl0=",
+        "ownerDid": "0xd7a5d0a364f335632cbbb59bb5615c12286f5b7298f6ddd58b584a6c08734538",
+        "ticker": "8TICKER",
+        "totalSupply": "1000100",
+        "totalTransfers": "0",
+        "transferManagers": Object {
+          "__typename": "TransferManagersConnection",
+          "nodes": Array [],
+        },
+        "type": "EquityCommon",
+      },
     ],
   },
 }

--- a/tests/entities/assets.test.ts
+++ b/tests/entities/assets.test.ts
@@ -7,7 +7,9 @@ describe('assets', () => {
     const q = {
       query: gql`
         query {
-          assets(filter: { ticker: { in: ["4TICKER", "15TICKER", "7TICKER", "11BTICKER1"] } }) {
+          assets(
+            filter: { ticker: { in: ["4TICKER", "15TICKER", "7TICKER", "8TICKER", "11BTICKER1"] } }
+          ) {
             nodes {
               nodeId
               id


### PR DESCRIPTION
### Description

- `AssetCreated` event now also emits `funding_round` and `identifiers`.
This updates them while asset creation
- Also, handles the `Byte` type funding round name and asset name
- Ignores `AssetTransfer` case when tokens are redeemed
- With chain version 5.0.0 lot of types were converted to `Bytes`, which
it handles now correctly
- Also, adds `memo` to the `PortfolioMovement` entity
- Fixes missing `funding_round` values for older chains (< 5.1.0)

### Breaking Changes

NA

### JIRA Link

DA-432, DA-433

### Checklist

- [ ] Updated the Readme.md (if required) ?
