### PR TITLE
fix: 🐛 Fix parsing of claim type in exempt keys

### DIFF
--- a/src/mappings/util.ts
+++ b/src/mappings/util.ts
@@ -5,6 +5,7 @@ import { SubstrateEvent, SubstrateExtrinsic } from '@subql/types';
 import { Portfolio } from 'polymesh-subql/types/models/Portfolio';
 import {
   AssetDocument,
+  ClaimTypeEnum,
   Compliance,
   Distribution,
   FoundType,
@@ -272,8 +273,17 @@ export const getExemptKeyValue = (
   const {
     asset: { ticker },
     op: opType,
-    claimType,
+    claimType: claimTypeValue,
   } = JSON.parse(item.toString());
+
+  let claimType;
+  if (!claimTypeValue || typeof claimTypeValue === 'string') {
+    claimType = claimTypeValue;
+  } else {
+    // from 5.1.0 chain version, Custom(CustomClaimTypeId) was added to the ClaimTypeEnum, polkadot now reads values as {"accredited": null}
+    claimType = capitalizeFirstLetter(Object.keys(claimTypeValue)[0]) as ClaimTypeEnum;
+  }
+
   return {
     assetId: hexToString(ticker),
     opType,


### PR DESCRIPTION
### Description

With 5.1.0 chain, the variant Custom(CustomClaimTypeId) was added to enum ClaimType. This changes how polkadot reads in the value for ClaimTypes. Earlier while parsing the exemptKey, it used to read the types as string values such as `Accredited`, but now it reads them as json values `{"accredited": null}`. This PR modifies the logic for parsing the exemptKey

### Breaking Changes

NA

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?
