### PR TITLE
fix: 🐛 Drop non-null constraint from `TickerExternalAgentAction.callerId`

### DIFF
--- a/db/migrations/8.4.2.sql
+++ b/db/migrations/8.4.2.sql
@@ -1,0 +1,2 @@
+-- Schema was altered to make `TickerExternalAgentAction.callerId` nullable
+ALTER TABLE ticker_external_agent_actions ALTER COLUMN caller_id DROP NOT NULL;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymesh-subquery",
-  "version": "5.5.0",
+  "version": "8.4.2",
   "author": "Polymesh Association",
   "license": "Apache 2.0",
   "description": "A Polymesh Chain Indexer, providing a GraphQL interface",

--- a/schema.graphql
+++ b/schema.graphql
@@ -1209,7 +1209,7 @@ type StakingEvent @entity {
 type TickerExternalAgentAction @entity {
   id: ID!
   asset: Asset! @index(unique: false)
-  caller: Identity! @index(unique: false)
+  caller: Identity @index(unique: false)
   palletName: String! @index(unique: false)
   eventId: EventIdEnum!
   eventIdx: Int!


### PR DESCRIPTION
### Description

This removes non-null constraint from
`TickerExternalAgentAction.callerId` to handle scenario where checkpoint is created via scheduler

Fixes the testnet issue for block 5871710 where checkpoints are created via scheduler
```
2022-11-22T09:38:34.892Z <fetch> INFO fetch block [5871710,5871809], total 100 blocks 
2022-11-22T09:38:36.767Z <sandbox> ERROR Received an error in handleEvent while handling the event 'checkpoint.CheckpointCreated': SequelizeValidationError: notNull Violation: TickerExternalAgentAction.callerId cannot be null
    at InstanceValidator._validate (/usr/local/lib/node_modules/@subql/node/node_modules/sequelize/lib/instance-validator.js:50:13)
```

### Breaking Changes

NA

### JIRA Link

DA-466

### Checklist

- [ ] Updated the Readme.md (if required) ?
