### PR TITLE
fix: 🐛 specify dockerfile location for github actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,6 +31,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          file: ./docker/sq-Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
### Description
[PR-98](https://github.com/PolymeshAssociation/polymesh-subquery/pull/98/files#diff-2bc030495cca422df1d48626427d805b36039015ab13ca4b2bdaea23affa1f33) moved `Dockerfile` -> `/docker/sq-Dockerfile` The build plugin defaults to `Dockerfile`, but lets us specify the location: with `file`. [Docs](https://github.com/docker/build-push-action#customizing)

### Breaking Changes

### JIRA Link

- uncovered in: [DA-464](https://polymesh.atlassian.net/browse/DA-464) 
- introduced in: [DA-401](https://polymesh.atlassian.net/browse/DA-401)

It wasn't uncovered in the initial merge since it was marked as a `chore` which semver bot skips

### Checklist

- [ ] Updated the Readme.md (if required) ?
