### PR TITLE
feat: 🎸 hardcode certain Subquery command flags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,6 @@ services:
       # - --scale-batch-size # scale batch size based on memory usage. To know more about the process - https://github.com/subquery/subql/blob/c9bc9733deef726f78fa48387e74e52f8d6ca8d2/packages/node/src/indexer/fetch.service.ts#L88
       # - --timeout=3600 # Timeout for indexer sandbox to execute the mapping functions (in seconds)
       # - --local # This is now deprecated
-      - --db-schema=public # Once tooling-gql is deprecated, we can change the schema name if required
       # - --force-clean # To remove all tables and schema before starting the app
       # - --workers=4 # Number of available CPU cores strictly limits the usage of worker threads. Read more here - https://academy.subquery.network/run_publish/references.html#w-workers
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,8 +56,6 @@ services:
       # - --local # This is now deprecated
       - --db-schema=public # Once tooling-gql is deprecated, we can change the schema name if required
       # - --force-clean # To remove all tables and schema before starting the app
-      - --timestamp-field # Enables created_at and updated_at in schema
-      - --disable-historical=true
       # - --workers=4 # Number of available CPU cores strictly limits the usage of worker threads. Read more here - https://academy.subquery.network/run_publish/references.html#w-workers
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://subquery-node:3000/ready']

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -34,8 +34,8 @@ NODE_SPACE=${MAX_OLD_SPACE_SIZE:-1536}
 
 node --max-old-space-size=$NODE_SPACE \
 	/usr/local/lib/node_modules/@subql/node/bin/run $@ \
-	--disable-historical=true
-	--timestamp-field
+	--disable-historical=true \
+	--timestamp-field \
 	--db-schema=public
 child=$!
 wait "$child"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -33,6 +33,8 @@ npm run migrations
 NODE_SPACE=${MAX_OLD_SPACE_SIZE:-1536}
 
 node --max-old-space-size=$NODE_SPACE \
-	/usr/local/lib/node_modules/@subql/node/bin/run $@
+	/usr/local/lib/node_modules/@subql/node/bin/run $@ \
+	--disable-historical=true
+	--timestamp-field
 child=$!
 wait "$child"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -36,5 +36,6 @@ node --max-old-space-size=$NODE_SPACE \
 	/usr/local/lib/node_modules/@subql/node/bin/run $@ \
 	--disable-historical=true
 	--timestamp-field
+	--db-schema=public
 child=$!
 wait "$child"


### PR DESCRIPTION
### Description

`disable-historical` is now always true, as there are issues enabling it. `timestamp-field` is always passed since its expected to have `created_at` timestamps on all records


### Breaking Changes

None. the args were supposed to be passed as the values they are now hard coded to, and passing the same argument twice didn't throw an error when I tried.

### JIRA Link

### Checklist

- [ ] Updated the Readme.md (if required) ?
