### PR TITLE
fix: 🐛 Drop foreign key constraint for `Leg.assetId`

### DIFF
--- a/db/migrations/8.5.04.sql
+++ b/db/migrations/8.5.04.sql
@@ -1,0 +1,1 @@
+alter table legs drop constraint if exists legs_asset_id_fkey;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymesh-subquery",
-  "version": "8.5.0",
+  "version": "8.5.04",
   "author": "Polymesh Association",
   "license": "Apache-2.0",
   "description": "A Polymesh Chain Indexer, providing a GraphQL interface",

--- a/schema.graphql
+++ b/schema.graphql
@@ -1361,7 +1361,7 @@ enum InstructionStatusEnum {
 
 type Leg @entity {
   id: ID! # instructionId/legIndex
-  asset: Asset!
+  assetId: String! # @prashantasdeveloper Replace this with `asset: Asset` when chain validations are fixed
   amount: BigInt!
   from: Portfolio! @index(unique: false)
   to: Portfolio! @index(unique: false)


### PR DESCRIPTION
### Description

As of now, chain doesn't validate the Legs to have a valid Asset ticker. This will be handled in on of the chain's future releases. To solve this now, we are dropping the foreign key constraint on the asset attribute of Leg entity. 

This problem was found in block 6101310 on testnet, erring as follows - 
```
2022-12-13T12:28:25.053Z <sandbox> ERROR Received an error in handleEvent while handling the event 'settlement.InstructionCreated': Error
    at Query.run (/usr/local/lib/node_modules/@subql/node/node_modules/sequelize/lib/dialects/postgres/query.js:50:25)
    at /usr/local/lib/node_modules/@subql/node/node_modules/sequelize/lib/sequelize.js:313:28
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async PostgresQueryInterface.upsert (/usr/local/lib/node_modules/@subql/node/node_modules/sequelize/lib/dialects/abstract/query-interface.js:330:12)
    at async Function.upsert (/usr/local/lib/node_modules/@subql/node/node_modules/sequelize/lib/model.js:1501:20)
    at async Object.set (/usr/local/lib/node_modules/@subql/node/dist/indexer/store.service.js:299:17) 
2022-12-13T12:28:25.055Z <fetch> ERROR failed to index block at height 6101310 handleEvent() SequelizeForeignKeyConstraintError: insert or update on table "legs" violates foreign key constraint "legs_asset_id_fkey"
```

### Breaking Changes

NA

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?
