### PR TITLE
fix: 🐛 Throw on migration query errors

### DIFF
--- a/db/migrations/8.4.3.sql
+++ b/db/migrations/8.4.3.sql
@@ -12,7 +12,7 @@ insert into stat_types(id, asset_id, op_type, created_block_id, updated_block_id
 select id || '/Count', id, 'Count', created_block_id, created_block_id, created_at, created_at
 from asset_data
 on conflict(id)
-do update do nothing
+do update
 set
 created_at = excluded.created_at,
 updated_at = excluded.created_at,


### PR DESCRIPTION
### Description

Currently, if there were any SQL errors in the migration queries the errors were not being known while adding them. Exiting the process on any such error will let us track these mistakes when tests are run.

### Breaking Changes

NA

### JIRA Link

DA-475

### Checklist

- [ ] Updated the Readme.md (if required) ?
