### PR TITLE
fix: 🐛 Update `Sto` entity to save data correctly

### DIFF
--- a/db/migrations/8.5.3.sql
+++ b/db/migrations/8.5.3.sql
@@ -1,0 +1,35 @@
+-- add sto_id column 
+alter table stos
+add column if not exists sto_id integer;
+
+-- create index for sto_id column
+create index if not exists stos_sto_id on stos using btree(sto_id);
+
+-- migrate current id column which stored the sto Id to sto_id column
+update stos set sto_id = id::int;
+
+-- set sto_id column to be not null to match the schema description
+alter table stos alter column sto_id set not null;
+
+-- update existing sto table entries to change their ID to `offeringAssetId/stoId`
+update stos set id = offering_asset_id || '/' || sto_id;
+
+-- fetch all the FundraiserCreated events and populate the missing entries in stos
+with sto_data as (
+  select 
+    event_arg_1 as sto_id, 
+    block_id, 
+    created_at, 
+    coalesce(
+      attributes->3->'value'->>'offeringAsset',
+      attributes->3->'value'->>'offering_asset' --needed for chain < 5.0.0
+    ) as offering_asset_id
+  from 
+    events e
+  where 
+    module_id = 'sto' and event_id = 'FundraiserCreated'
+)
+insert into stos(id, offering_asset_id, sto_id, created_block_id, updated_block_id, created_at, updated_at) 
+select sto_data.offering_asset_id || '/' || sto_data.sto_id, sto_data.offering_asset_id, sto_data.sto_id::int, sto_data.block_id, sto_data.block_id,  sto_data.created_at, sto_data.created_at
+from sto_data
+on conflict(id) do nothing;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymesh-subquery",
-  "version": "8.5.1",
+  "version": "8.5.3",
   "author": "Polymesh Association",
   "license": "Apache-2.0",
   "description": "A Polymesh Chain Indexer, providing a GraphQL interface",

--- a/schema.graphql
+++ b/schema.graphql
@@ -1219,6 +1219,7 @@ type TickerExternalAgentAction @entity {
 
 type Sto @entity {
   id: ID!
+  stoId: Int! @index(unique: false)
   offeringAsset: Asset!
   createdBlock: Block!
   updatedBlock: Block!

--- a/src/mappings/entities/mapSto.ts
+++ b/src/mappings/entities/mapSto.ts
@@ -1,5 +1,5 @@
 import { EventIdEnum, ModuleIdEnum, Sto } from '../../types';
-import { getOfferingAsset, getTextValue } from '../util';
+import { getNumberValue, getOfferingAsset } from '../util';
 import { HandlerArgs } from './common';
 
 /**
@@ -9,9 +9,11 @@ export async function mapSto({ blockId, eventId, moduleId, params }: HandlerArgs
   if (moduleId === ModuleIdEnum.sto && eventId === EventIdEnum.FundraiserCreated) {
     const [, rawStoId, , rawFundraiser] = params;
     const offeringAssetId = getOfferingAsset(rawFundraiser);
+    const stoId = getNumberValue(rawStoId);
 
     await Sto.create({
-      id: getTextValue(rawStoId),
+      id: `${offeringAssetId}/${stoId}`,
+      stoId,
       offeringAssetId,
       createdBlockId: blockId,
       updatedBlockId: blockId,

--- a/src/mappings/util.ts
+++ b/src/mappings/util.ts
@@ -113,12 +113,20 @@ export const serializeAccount = (item: Codec): string | null => {
   return u8aToHex(decodeAddress(item.toString(), false, item.registry.chainSS58));
 };
 
+export const getNthKeyFromJson = (item: Codec, index = 0): string => {
+  return Object.keys(item.toJSON())[index];
+};
+
+export const getNthValueFromJson = (item: Codec, index = 0): string => {
+  return item.toJSON()[getNthKeyFromJson(item, index)];
+};
+
 export const getFirstKeyFromJson = (item: Codec): string => {
-  return Object.keys(item.toJSON())[0];
+  return getNthKeyFromJson(item);
 };
 
 export const getFirstValueFromJson = (item: Codec): string => {
-  return item.toJSON()[getFirstKeyFromJson(item)];
+  return getNthValueFromJson(item);
 };
 
 export const getTextValue = (item: Codec): string => {


### PR DESCRIPTION
### Description

Sto entity was overriding data for various offerings based on the ID. For example, if there were two Sto's created lets say for TICKER1 with id 0 and TICKER2 with id 0 in that mentioned order, TICKER1 with 0 was overridden in database with TICKER2 with 0. 

To fix it we have added a new attribute `stoId` to the `Sto` entity and the Sto handler now correctly generates unique ID for Sto as combination of offering Asset and Sto ID fixing the problem.

### Breaking Changes

🧨 Sto ID for an offering Asset is now stored in `stoId` attribute instead of `id` attribute of `Sto`

### JIRA Link

DA-521

### Checklist

- [ ] Updated the Readme.md (if required) ?
