### PR TITLE
ci: 🎡 Update docker github actions to latest version

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,22 +13,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.ASSOCIATION_DOCKER_USERNAME }}
           password: ${{ secrets.ASSOCIATION_DOCKER_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ secrets.ASSOCIATION_DOCKER_HUB_REPO }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./docker/sq-Dockerfile


### PR DESCRIPTION
### Description

This removes the warning `The "save-state" command is deprecated and will be disabled soon. Please upgrade to using Environment Files.` while building and pushing docker image

Reference job link - https://github.com/PolymeshAssociation/polymesh-subquery/actions/runs/3639617801/jobs/6144319522

### Breaking Changes

NA

### JIRA Link

DA-459

### Checklist

- [ ] Updated the Readme.md (if required) ?
