### PR TITLE
jenkins build pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,80 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+
+node {
+
+    properties([
+        [$class: 'BuildDiscarderProperty',
+         strategy: [$class: 'LogRotator',
+                    artifactDaysToKeepStr: '7',
+                    artifactNumToKeepStr: '7',
+                    daysToKeepStr: '7',
+                    numToKeepStr: '7']],
+    ])
+
+    WORKSPACE_PATH = "${JENKINS_HOME}/workspace/${JOB_NAME}/${BUILD_NUMBER}"
+
+    dir(WORKSPACE_PATH) {
+
+        IS_PULL_REQUEST = true
+
+        if (env.CHANGE_BRANCH) {
+            echo "Job was started from a pull request"
+        } else {
+            IS_PULL_REQUEST = false
+            echo "Job was started from a branch"
+        }
+
+        SCM_CHECKOUT_BRANCHES = [
+
+        ]
+        SCM_CHECKOUT_EXTENSIONS = [
+            [$class: 'UserIdentity',
+              name: 'Jenkins',
+              email: 'sre@polymesh.network'],
+        ]
+
+        if (IS_PULL_REQUEST) {
+            //SCM_CHECKOUT_BRANCHES.push([name: "*/${env.CHANGE_TARGET}"])
+            SCM_CHECKOUT_BRANCHES.push([name: "*/${env.CHANGE_BRANCH}"])
+            //SCM_CHECKOUT_EXTENSIONS.push([$class: 'PreBuildMerge',
+            //                               options: [mergeRemote: 'origin',
+            //                                         mergeTarget: env.CHANGE_TARGET]])
+        } else {
+            SCM_CHECKOUT_BRANCHES.push([name: "*/${env.BRANCH_NAME}"])
+        }
+
+        echo "Performing repo checkout"
+
+        scm_variables = checkout([$class: 'GitSCM',
+                                  branches: SCM_CHECKOUT_BRANCHES,
+                                  extensions: SCM_CHECKOUT_EXTENSIONS,
+
+                                  //traits: [ // to-do
+                                  //  skipNotifications(),
+                                  //]
+
+                                  userRemoteConfigs: [[url: 'https://github.com/PolymeshAssociation/polymesh-subquery.git',
+                                                       credentialsId: 'github_username_personal_access_token']]])
+
+        env.GIT_COMMIT = scm_variables.get('GIT_COMMIT')
+        echo "GIT_COMMIT: ${env.GIT_COMMIT}"
+
+        stage('Build') {
+            sh (label: 'Run `./build.sh`',
+                script: './build.sh')
+        }
+
+        //stage('Test') {
+        //    sh (label: 'Run `./test.sh`',
+        //        script: './test.sh')
+        //}
+
+        stage('Push') {
+            sh (label: 'Run `./push.sh`',
+                script: './push.sh')
+        }
+
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////

--- a/deploy/.env.template
+++ b/deploy/.env.template
@@ -1,0 +1,9 @@
+DB_USER=postgres
+DB_PASS=postgres
+DB_DATABASE=postgres
+DB_HOST=postgres
+DB_PORT=5432
+START_BLOCK=1
+#NO_NATIVE_GRAPHQL_DATA=true
+NETWORK_ENDPOINT=ws://host.docker.internal:9944
+NETWORK_HTTP_ENDPOINT=http://host.docker.internal:9933

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -exu -o pipefail
+
+: "${AWS_REGION:=us-west-2}"
+: "${CONTAINER_REGISTRY:=201135299591.dkr.ecr.${AWS_REGION}.amazonaws.com}"
+: "${CONTAINER_TAG:=$(git rev-parse HEAD)}"
+
+docker build -f docker/sq-Dockerfile -t "${CONTAINER_REGISTRY}/polymesh/subquery:${CONTAINER_TAG}" .

--- a/deploy/push.sh
+++ b/deploy/push.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -exu -o pipefail
+
+: "${AWS_PROFILE:=polymesh_primary}"
+: "${AWS_REGION:=us-west-2}"
+: "${CONTAINER_REGISTRY:=201135299591.dkr.ecr.${AWS_REGION}.amazonaws.com}"
+: "${CONTAINER_TAG:=$(git rev-parse HEAD)}"
+
+export AWS_REGION
+export AWS_DEFAULT_REGION=$AWS_REGION
+
+if [[ $(whoami) != "jenkins" ]]; then
+    export AWS_PROFILE=$AWS_PROFILE
+fi
+
+aws ecr get-login-password | \
+    docker login "$CONTAINER_REGISTRY" --username AWS --password-stdin
+
+docker push "${CONTAINER_REGISTRY}/polymesh/subquery:${CONTAINER_TAG}" || true # temporary workaround for "... image tag already exists... and cannot be overwritten because the repository is immutable."

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -exu -o pipefail
+
+: "${AWS_REGION:=us-west-2}"
+: "${CONTAINER_REGISTRY:=201135299591.dkr.ecr.${AWS_REGION}.amazonaws.com}"
+: "${CONTAINER_TAG:=$(git rev-parse HEAD)}"
+
+docker run --rm \
+           -it \
+           --env-file ./deploy/.env.template \
+           "${CONTAINER_REGISTRY}/polymesh/subquery:${CONTAINER_TAG}"


### PR DESCRIPTION
- adds basic jenkins build pipeline

currently the container [image](https://hub.docker.com/layers/polymeshassociation/polymesh-subquery/v9.0.0/images/sha256-09b509005bd99f94788edbfbae264a9afa7450a26b0d97603c104126f7cba3cc?context=explore) for `polymeshassociation/polymesh-subquery:v9.0.0` does not support `linux/arm64`, however, the upstream [image](https://hub.docker.com/layers/onfinality/subql-node/v1.13.3/images/sha256-322e4794c04a67715cd63a79ba2214f46cab5d646b2fe22f24c7f3ec434b1bae?context=explore) for `onfinality/subql-node:v1.13.3` does; this PR makes builds for `linux/arm64` available under a private registry, for testing