### PR TITLE
jenkins build pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,6 @@ node {
         ]
 
         if (IS_PULL_REQUEST) {
-            //SCM_CHECKOUT_BRANCHES.push([name: "*/${env.CHANGE_TARGET}"])
             SCM_CHECKOUT_BRANCHES.push([name: "*/${env.CHANGE_BRANCH}"])
             //SCM_CHECKOUT_EXTENSIONS.push([$class: 'PreBuildMerge',
             //                               options: [mergeRemote: 'origin',
@@ -48,11 +47,6 @@ node {
         scm_variables = checkout([$class: 'GitSCM',
                                   branches: SCM_CHECKOUT_BRANCHES,
                                   extensions: SCM_CHECKOUT_EXTENSIONS,
-
-                                  //traits: [ // to-do
-                                  //  skipNotifications(),
-                                  //]
-
                                   userRemoteConfigs: [[url: 'https://github.com/PolymeshAssociation/polymesh-subquery.git',
                                                        credentialsId: 'github_username_personal_access_token']]])
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,80 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+
+node {
+
+    properties([
+        [$class: 'BuildDiscarderProperty',
+         strategy: [$class: 'LogRotator',
+                    artifactDaysToKeepStr: '7',
+                    artifactNumToKeepStr: '7',
+                    daysToKeepStr: '7',
+                    numToKeepStr: '7']],
+    ])
+
+    WORKSPACE_PATH = "${JENKINS_HOME}/workspace/${JOB_NAME}/${BUILD_NUMBER}"
+
+    dir(WORKSPACE_PATH) {
+
+        IS_PULL_REQUEST = true
+
+        if (env.CHANGE_BRANCH) {
+            echo "Job was started from a pull request"
+        } else {
+            IS_PULL_REQUEST = false
+            echo "Job was started from a branch"
+        }
+
+        SCM_CHECKOUT_BRANCHES = [
+
+        ]
+        SCM_CHECKOUT_EXTENSIONS = [
+            [$class: 'UserIdentity',
+              name: 'Jenkins',
+              email: 'sre@polymesh.network'],
+        ]
+
+        if (IS_PULL_REQUEST) {
+            //SCM_CHECKOUT_BRANCHES.push([name: "*/${env.CHANGE_TARGET}"])
+            SCM_CHECKOUT_BRANCHES.push([name: "*/${env.CHANGE_BRANCH}"])
+            //SCM_CHECKOUT_EXTENSIONS.push([$class: 'PreBuildMerge',
+            //                               options: [mergeRemote: 'origin',
+            //                                         mergeTarget: env.CHANGE_TARGET]])
+        } else {
+            SCM_CHECKOUT_BRANCHES.push([name: "*/${env.BRANCH_NAME}"])
+        }
+
+        echo "Performing repo checkout"
+
+        scm_variables = checkout([$class: 'GitSCM',
+                                  branches: SCM_CHECKOUT_BRANCHES,
+                                  extensions: SCM_CHECKOUT_EXTENSIONS,
+
+                                  //traits: [ // to-do
+                                  //  skipNotifications(),
+                                  //]
+
+                                  userRemoteConfigs: [[url: 'https://github.com/PolymeshAssociation/polymesh-subquery.git',
+                                                       credentialsId: 'github_username_personal_access_token']]])
+
+        env.GIT_COMMIT = scm_variables.get('GIT_COMMIT')
+        echo "GIT_COMMIT: ${env.GIT_COMMIT}"
+
+        stage('Build') {
+            sh (label: 'Run `./build.sh`',
+                script: './build.sh')
+        }
+
+        //stage('Test') {
+        //    sh (label: 'Run `./test.sh`',
+        //        script: './test.sh')
+        //}
+
+        stage('Push') {
+            sh (label: 'Run `./push.sh`',
+                script: './push.sh')
+        }
+
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,18 +60,18 @@ node {
         echo "GIT_COMMIT: ${env.GIT_COMMIT}"
 
         stage('Build') {
-            sh (label: 'Run `./build.sh`',
-                script: './build.sh')
+            sh (label: 'Run `./deploy/build.sh`',
+                script: './deploy/build.sh')
         }
 
         //stage('Test') {
-        //    sh (label: 'Run `./test.sh`',
-        //        script: './test.sh')
+        //    sh (label: 'Run `./deploy/test.sh`',
+        //        script: './deploy/test.sh')
         //}
 
         stage('Push') {
-            sh (label: 'Run `./push.sh`',
-                script: './push.sh')
+            sh (label: 'Run `./deploy/push.sh`',
+                script: './deploy/push.sh')
         }
 
     }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The behavior of the dev image can be controlled by setting ENV variables. The de
 
 - `NETWORK_ENDPOINT` - the wss endpoint of the blockchain to be indexed
 - `NETWORK_CHAIN_ID` - The genesis hash of the chain. This value can be retrieved by going to the explorer and looking for the block hash of block 0. e.g. [for mainnet](https://mainnet-app.polymesh.network/#/explorer/query/0)
-- `START_BLOCK` - block from which indexing should start. Generally this should be set to 0, but other values can be useful for debugging.
+- `START_BLOCK` - block from which indexing should start. Generally this should be set to 1, but other values can be useful for debugging.
 
 More advanced options are:
 

--- a/deploy/.env.template
+++ b/deploy/.env.template
@@ -1,0 +1,9 @@
+DB_USER=postgres
+DB_PASS=postgres
+DB_DATABASE=postgres
+DB_HOST=postgres
+DB_PORT=5432
+START_BLOCK=1
+#NO_NATIVE_GRAPHQL_DATA=true
+NETWORK_ENDPOINT=ws://host.docker.internal:9944
+NETWORK_HTTP_ENDPOINT=http://host.docker.internal:9933

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,7 +3,7 @@ RUN addgroup subquery && adduser --uid 1001 -G subquery -D --shell /bin/false su
 RUN apk add --no-cache bash gettext
 
 # arm64 dependencies
-RUN apk add --no-cache python3 pythonispython3 make gcc
+RUN apk add --no-cache python3 pythonispython3 make gcc musl-dev
 
 # Dependencies
 WORKDIR /app

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,20 @@
+FROM onfinality/subql-node:v1.13.3
+RUN addgroup subquery && adduser --uid 1001 -G subquery -D --shell /bin/false subquery
+RUN apk add --no-cache bash gettext
+
+# arm64 dependencies
+RUN apk add --no-cache python3 pythonispython3
+
+# Dependencies
+WORKDIR /app
+COPY package.json /app
+COPY yarn.lock /app
+RUN yarn --frozen-lockfile && chown -R subquery /app
+
+ENTRYPOINT [ "/sbin/tini", "--", "bash", "/app/docker/docker-entrypoint.sh" ]
+
+# End of cache
+COPY . /app
+
+RUN envsubst < project.template.yaml > project.yaml && yarn codegen && yarn build && rm project.yaml && chown -R subquery $(ls /app |grep -v 'node_modules')
+USER subquery

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,8 +3,7 @@ RUN addgroup subquery && adduser --uid 1001 -G subquery -D --shell /bin/false su
 RUN apk add --no-cache bash gettext
 
 # arm64 dependencies
-RUN apk add --no-cache python3 pythonispython3 make
-
+RUN apk add --no-cache python3 pythonispython3 make gcc
 
 # Dependencies
 WORKDIR /app

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,7 +3,7 @@ RUN addgroup subquery && adduser --uid 1001 -G subquery -D --shell /bin/false su
 RUN apk add --no-cache bash gettext
 
 # arm64 dependencies
-RUN apk add --no-cache python3 pythonispython3 make gcc musl-dev
+RUN apk add --no-cache python3 pythonispython3 make gcc g++ musl-dev
 
 # Dependencies
 WORKDIR /app

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,7 +3,8 @@ RUN addgroup subquery && adduser --uid 1001 -G subquery -D --shell /bin/false su
 RUN apk add --no-cache bash gettext
 
 # arm64 dependencies
-RUN apk add --no-cache python3 pythonispython3
+RUN apk add --no-cache python3 pythonispython3 make
+
 
 # Dependencies
 WORKDIR /app

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -exu -o pipefail
+
+: "${AWS_REGION:=us-west-2}"
+: "${CONTAINER_REGISTRY:=201135299591.dkr.ecr.${AWS_REGION}.amazonaws.com}"
+: "${CONTAINER_TAG:=$(git rev-parse HEAD)}"
+
+docker build -f docker/sq-Dockerfile -t "${CONTAINER_REGISTRY}/polymesh/subquery:${CONTAINER_TAG}" .

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -6,4 +6,4 @@ set -exu -o pipefail
 : "${CONTAINER_REGISTRY:=201135299591.dkr.ecr.${AWS_REGION}.amazonaws.com}"
 : "${CONTAINER_TAG:=$(git rev-parse HEAD)}"
 
-docker build -f docker/sq-Dockerfile -t "${CONTAINER_REGISTRY}/polymesh/subquery:${CONTAINER_TAG}" .
+docker build -f deploy/Dockerfile -t "${CONTAINER_REGISTRY}/polymesh/subquery:${CONTAINER_TAG}" .

--- a/deploy/push.sh
+++ b/deploy/push.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -exu -o pipefail
+
+: "${AWS_PROFILE:=polymesh_primary}"
+: "${AWS_REGION:=us-west-2}"
+: "${CONTAINER_REGISTRY:=201135299591.dkr.ecr.${AWS_REGION}.amazonaws.com}"
+: "${CONTAINER_TAG:=$(git rev-parse HEAD)}"
+
+export AWS_REGION
+export AWS_DEFAULT_REGION=$AWS_REGION
+
+if [[ $(whoami) != "jenkins" ]]; then
+    export AWS_PROFILE=$AWS_PROFILE
+fi
+
+aws ecr get-login-password | \
+    docker login "$CONTAINER_REGISTRY" --username AWS --password-stdin
+
+docker push "${CONTAINER_REGISTRY}/polymesh/subquery:${CONTAINER_TAG}" || true # temporary workaround for "... image tag already exists... and cannot be overwritten because the repository is immutable."

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -exu -o pipefail
+
+: "${AWS_REGION:=us-west-2}"
+: "${CONTAINER_REGISTRY:=201135299591.dkr.ecr.${AWS_REGION}.amazonaws.com}"
+: "${CONTAINER_TAG:=$(git rev-parse HEAD)}"
+
+docker run --rm \
+           -it \
+           --env-file ./deploy/.env.template \
+           "${CONTAINER_REGISTRY}/polymesh/subquery:${CONTAINER_TAG}"


### PR DESCRIPTION
- adds basic jenkins build pipeline

currently the container [image](https://hub.docker.com/layers/polymeshassociation/polymesh-subquery/v9.0.0/images/sha256-09b509005bd99f94788edbfbae264a9afa7450a26b0d97603c104126f7cba3cc?context=explore) for `polymeshassociation/polymesh-subquery:v9.0.0` does not support `linux/arm64`, however, the upstream [image](https://hub.docker.com/layers/onfinality/subql-node/v1.13.3/images/sha256-322e4794c04a67715cd63a79ba2214f46cab5d646b2fe22f24c7f3ec434b1bae?context=explore) for `onfinality/subql-node:v1.13.3` does; this PR makes builds for `linux/arm64` available under a private registry, for testing

- adds distinct `Dockerfile` for arm64 builds; this could be considered for merging with the one located @ `docker/sq-Dockerfile`

- fixes docs - running with `START_BLOCK=1` results in the following error:
    
```
    <fetch> ERROR failed to fetch RuntimeVersion at block 0x0000000000000000000000000000000000000000000000000000000000000000
    <BlockDispatcherService> ERROR Failed to fetch blocks from queue Error: Unable to retrieve header and parent from supplied hash
```