### PR TITLE
fix: 🐛 Handle STO status correctly for chain < 5.0.0

### DIFF
--- a/db/migrations/9.2.02.sql
+++ b/db/migrations/9.2.02.sql
@@ -60,7 +60,7 @@ with sto_data as (
       ) as offering_portfolio,
     coalesce(
         attributes->3->'value'->>'raisingAsset',
-        attributes->3->'value'->>'raisiing_asset' --needed for chain < 5.0.0
+        attributes->3->'value'->>'raising_asset' --needed for chain < 5.0.0
       ) as raising_asset_id,
     coalesce(
         attributes->3->'value'->'raisingPortfolio',
@@ -70,7 +70,7 @@ with sto_data as (
     to_timestamp(("attributes"->3->'value'->>'start')::NUMERIC/1000) as start,
     to_timestamp(("attributes"->3->'value'->>'end')::NUMERIC/1000) as end,
     "attributes"->3->'value'->'tiers' as tiers,
-    "attributes"->3->'value'->>'status' as status,
+    'Live' as status,
     coalesce(
         attributes->3->'value'->'minimumInvestment',
         attributes->3->'value'->'minimum_investment' --needed for chain < 5.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymesh-subquery",
-  "version": "9.2.03",
+  "version": "9.2.04",
   "author": "Polymesh Association",
   "license": "Apache-2.0",
   "description": "A Polymesh Chain Indexer, providing a GraphQL interface",

--- a/src/mappings/util.ts
+++ b/src/mappings/util.ts
@@ -408,9 +408,15 @@ export const getFundraiserDetails = (item: Codec): Omit<Attributes<Sto>, 'stoId'
   const offeringPortfolio = meshPortfolioToPortfolio(extractValue(rest, 'offering_portfolio'));
   const raisingPortfolio = meshPortfolioToPortfolio(extractValue(rest, 'raising_portfolio'));
 
+  let stoStatus = status;
+  if (typeof status !== 'string') {
+    // for chain < 5.0.0, status comes as {'live': []}
+    stoStatus = capitalizeFirstLetter(Object.keys(status)[0]);
+  }
+
   return {
     creatorId,
-    status,
+    status: stoStatus,
     start: getDateValue(start),
     end: getDateValue(end),
     tiers,


### PR DESCRIPTION
### Description

StoStatus is processed differently for older chains. This PR makes changes to handle both cases and also makes changes in migration file to handle the same.

(Noticed this in testnet and mainnet old blocks)

### Breaking Changes

NA

### JIRA Link

DA-522

### Checklist

- [ ] Updated the Readme.md (if required) ?
