### PR TITLE
fix: 🐛 Add `StoStatus` with migration

### DIFF
--- a/db/migrations/9.2.02.sql
+++ b/db/migrations/9.2.02.sql
@@ -1,3 +1,12 @@
+-- Create StoStatus enum
+DO $$
+BEGIN
+    IF NOT EXISTS (select 1 from pg_type where typname = 'public_enum_9ceea16a44') then
+        create type public_enum_9ceea16a44 AS ENUM ('Live', 'Frozen', 'Closed', 'ClosedEarly');
+    END IF;
+END
+$$;
+
 /** 
  * STO entity creation - Add new columns, index and constraints for each newly added attribute in the entity
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymesh-subquery",
-  "version": "9.2.04",
+  "version": "9.2.05",
   "author": "Polymesh Association",
   "license": "Apache-2.0",
   "description": "A Polymesh Chain Indexer, providing a GraphQL interface",


### PR DESCRIPTION
### Description

When bumping versions non-incrementally, migration 9.2.02.sql throws error that `public_enum_9ceea16a44` is missing. 
In case of incremental bumping of version, it gets automatically created. Added in migration to handle both cases

### Breaking Changes

NA

### JIRA Link

DA-522

### Checklist

- [ ] Updated the Readme.md (if required) ?
