### PR TITLE
fix: 🐛 Update existing migration queries to ensure idempotence

### DIFF
--- a/db/old_migrations/9.0.0.sql
+++ b/db/old_migrations/9.0.0.sql
@@ -6,30 +6,10 @@ add column if not exists sto_id integer;
 create index if not exists stos_sto_id on stos using btree(sto_id);
 
 -- migrate current id column which stored the sto Id to sto_id column
-update stos set sto_id = id::int;
+update stos set sto_id = id::int where sto_id is null and id SIMILAR TO '[0-9]+';
 
 -- set sto_id column to be not null to match the schema description
 alter table stos alter column sto_id set not null;
 
 -- update existing sto table entries to change their ID to `offeringAssetId/stoId`
-update stos set id = offering_asset_id || '/' || sto_id;
-
--- fetch all the FundraiserCreated events and populate the missing entries in stos
-with sto_data as (
-  select 
-    event_arg_1 as sto_id, 
-    block_id, 
-    created_at, 
-    coalesce(
-      attributes->3->'value'->>'offeringAsset',
-      attributes->3->'value'->>'offering_asset' --needed for chain < 5.0.0
-    ) as offering_asset_id
-  from 
-    events e
-  where 
-    module_id = 'sto' and event_id = 'FundraiserCreated'
-)
-insert into stos(id, offering_asset_id, sto_id, created_block_id, updated_block_id, created_at, updated_at) 
-select sto_data.offering_asset_id || '/' || sto_data.sto_id, sto_data.offering_asset_id, sto_data.sto_id::int, sto_data.block_id, sto_data.block_id,  sto_data.created_at, sto_data.created_at
-from sto_data
-on conflict(id) do nothing;
+update stos set id = offering_asset_id || '/' || sto_id where id SIMILAR TO '[0-9]+';

--- a/db/old_migrations/9.7.01.sql
+++ b/db/old_migrations/9.7.01.sql
@@ -107,4 +107,5 @@ where
         then event_arg_2::jsonb->>'did' != '0x0000000000000000000000000000000000000000000000000000000000000000' 
       else true 
     end
-order by b.block_id;
+order by b.block_id
+on conflict(id) do nothing;


### PR DESCRIPTION
### Description

With new migration sequencing, all the old ones are executed once to make sure that anyone running the instance of SQ has not missed the old migrations and now can follow the new migration sequencing. This requires couple of old migrations to be modified to ensure idempotent nature of queries. 

1. `9.0.0.sql` - all the sto updates are already handled in the `9.2.02.sql`, so the update query is not needed anymore
2. `9.7.01.sql` - needed to prevent duplicate entry failure, so need to add conflict check on id

### Breaking Changes

NA

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?
