### PR TITLE
fix: 🐛 Update queries to correctly create "migrations"

### DIFF
--- a/db/migrations/1_migration_entity.sql
+++ b/db/migrations/1_migration_entity.sql
@@ -2,6 +2,8 @@ create table if not exists migrations (
     id text not null,
     "number" numeric not null,
     version text not null,
+    executed boolean not null,
+    processed_block integer not null,
     created_at timestamptz not null,
     updated_at timestamptz not null,
     PRIMARY KEY (id)

--- a/db/migrations/3_polyx_transactions_entity.sql
+++ b/db/migrations/3_polyx_transactions_entity.sql
@@ -2,6 +2,10 @@ alter table migrations add column if not exists executed boolean;
 update migrations set executed = false where executed is null;
 alter table migrations alter column executed set not null;
 
+alter table migrations add column if not exists processed_block integer;
+update migrations set processed_block = 0 where processed_block is null;
+alter table migrations alter column processed_block set not null;
+
 DO $$
 BEGIN
     IF NOT EXISTS (select 1 from pg_type where typname = 'public_enum_5df0f1d22c') then


### PR DESCRIPTION
### Description

In a scenario where someone hasn't executed migration 1,2,3 and directly updates to latest alpha, SQ was erring that it couldn't find `processed_block` column in `migrations` table. To fix that, this PR adds the newly added columns of the migration entity in previous migrations as well. Those who may have executed the latest alpha successfully, won't be affected by this.

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
