### PR TITLE
fix: 🐛 Add query to handle missing columns from `migration`

### DIFF
--- a/db/migrations/2_update_schema_for_6_0_0_chain.sql
+++ b/db/migrations/2_update_schema_for_6_0_0_chain.sql
@@ -1,3 +1,11 @@
+alter table migrations add column if not exists executed boolean;
+update migrations set executed = false where executed is null;
+alter table migrations alter column executed set not null;
+
+alter table migrations add column if not exists processed_block integer;
+update migrations set processed_block = 0 where processed_block is null;
+alter table migrations alter column processed_block set not null;
+
 alter type public_enum_0bf3c7d4ef add value if not exists 'exempt_ticker_affirmation' after 'create_asset_with_custom_type';
 alter type public_enum_0bf3c7d4ef add value if not exists 'pre_approve_ticker' after 'make_divisible';
 alter type public_enum_0bf3c7d4ef add value if not exists 'remove_ticker_affirmation_exemption' after 'remove_metadata_value';


### PR DESCRIPTION
### Description

On migrating from older version, the SQ startup was erring with missing columns in `migration` entity. This will allow users to migration from any older version to latest version

### Breaking Changes

NA

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?
