### PR TITLE
feat: 🎸 Add support for child identities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ project.yaml
 tsconfig.tsbuildinfo
 
 metadata.json
+.history

--- a/schema.graphql
+++ b/schema.graphql
@@ -1349,6 +1349,7 @@ type Identity @entity {
   updatedBlock: Block!
   heldAssets: [AssetHolder]! @derivedFrom(field: "identity")
   portfolios: [Portfolio!]! @derivedFrom(field: "identity")
+  children: [ChildIdentity!]! @derivedFrom(field: "parent")
 }
 
 """
@@ -2146,6 +2147,17 @@ type PolyxTransaction @entity {
   extrinsic: Extrinsic
   datetime: Date!
   eventIdx: Int!
+  createdBlock: Block!
+  updatedBlock: Block!
+}
+
+"""
+Represents the parent child mapping for an Identity
+"""
+type ChildIdentity @entity {
+  id: ID!
+  child: Identity!
+  parent: Identity!
   createdBlock: Block!
   updatedBlock: Block!
 }


### PR DESCRIPTION
### Description

This adds a new entity `ChildIdentity` which save the mapping between a parent and child Identity. We can inversely query the children using the `children` field in `Identity` entity

### Breaking Changes

NA

### JIRA Link

DA-887

### Checklist

- [ ] Updated the Readme.md (if required) ?
