### PR TITLE
fix: 🐛 Correctly populate the event value for AssetTransaction

### DIFF
--- a/db/migrations/2_populate_instruction_to_asset_transaction.sql
+++ b/db/migrations/2_populate_instruction_to_asset_transaction.sql
@@ -50,7 +50,7 @@ with update_data as (
 from 
 asset_transactions txs
 inner join events e on e.block_id = txs.created_block_id and e.event_idx = txs.event_idx
-and e.event_id in ('AssetBalanceUpdated', 'NFTPortfolioUpdated')
+and e.event_id = 'AssetBalanceUpdated'
 where txs.event_id = 'Transfer'
 )
 update 

--- a/db/migrations/3_fix_asset_transaction_event.sql
+++ b/db/migrations/3_fix_asset_transaction_event.sql
@@ -1,0 +1,10 @@
+-- update the event types for NFT related asset transactions correctly
+update asset_transactions
+set event_id = (case 
+      when from_portfolio_id is null
+        then case when amount is not null then 'Issued' else 'IssuedNFT' end
+      when to_portfolio_id is null
+        then case when amount is not null then 'Redeemed' else 'RedeemedNFT' end
+      end)::"8f5a39c8ee"
+where 
+  from_portfolio_id is null or to_portfolio_id is null;

--- a/db/migrations/3_fix_asset_transaction_event.sql
+++ b/db/migrations/3_fix_asset_transaction_event.sql
@@ -8,3 +8,24 @@ set event_id = (case
       end)::"8f5a39c8ee"
 where 
   from_portfolio_id is null or to_portfolio_id is null;
+
+with update_data as (
+  select 
+  txs.id,
+  e.attributes->4->'value'->'Transferred'->>'instructionId' as instruction_id
+from 
+asset_transactions txs
+inner join events e on e.block_id = txs.created_block_id and e.event_idx = txs.event_idx
+and e.event_id = 'NFTPortfolioUpdated'
+where txs.event_id = 'Transfer'
+)
+update 
+  asset_transactions ast
+set 
+  instruction_id = inst.id, 
+  instruction_memo = inst.memo
+from 
+  update_data d 
+inner join instructions inst on inst.id = d.instruction_id
+where 
+  d.id = ast.id;

--- a/src/mappings/entities/mapAsset.ts
+++ b/src/mappings/entities/mapAsset.ts
@@ -67,6 +67,7 @@ export const createAssetTransaction = (
     | 'instructionId'
     | 'instructionMemo'
   >,
+  eventId?: EventIdEnum,
   extrinsic?: SubstrateExtrinsic
 ): Promise<void> => {
   const callId = camelToSnakeCase(extrinsic?.extrinsic.method.method || 'default');
@@ -87,7 +88,7 @@ export const createAssetTransaction = (
   return AssetTransaction.create({
     id: `${blockId}/${eventIdx}`,
     ...details,
-    eventId: callToEventMappings[callId] || callToEventMappings['default'],
+    eventId: callToEventMappings[callId] || eventId || callToEventMappings['default'],
     eventIdx,
     extrinsicIdx: extrinsic?.idx,
     datetime,
@@ -438,6 +439,7 @@ const handleAssetTransfer = async ({
         amount: transferAmount,
         instructionId,
       },
+      EventIdEnum.Transfer,
       extrinsic
     )
   );
@@ -496,7 +498,9 @@ const handleAssetBalanceUpdated = async ({
 
   const value = getFirstValueFromJson(rawUpdateReason);
 
+  let eventId: EventIdEnum;
   if (updateReason === 'issued') {
+    eventId = EventIdEnum.Issued;
     const issuedReason = value as unknown as { fundingRoundName: string };
     fundingRoundName = coerceHexToString(issuedReason.fundingRoundName);
 
@@ -518,6 +522,7 @@ const handleAssetBalanceUpdated = async ({
     asset.updatedBlockId = blockId;
     promises.push(asset.save());
   } else if (updateReason === 'redeemed') {
+    eventId = EventIdEnum.Redeemed;
     asset.totalSupply -= transferAmount;
     asset.updatedBlockId = blockId;
     promises.push(asset.save());
@@ -529,6 +534,11 @@ const handleAssetBalanceUpdated = async ({
 
     instructionId = getTextValue(details.instructionId);
     instructionMemo = bytesToString(details.instructionMemo);
+
+    eventId = EventIdEnum.Transfer;
+    if (!instructionId) {
+      eventId = block.events[eventIdx + 1]?.event?.method as EventIdEnum;
+    }
 
     asset.totalTransfers += BigInt(1);
     asset.updatedBlockId = blockId;
@@ -549,6 +559,7 @@ const handleAssetBalanceUpdated = async ({
         instructionId,
         instructionMemo,
       },
+      eventId,
       extrinsic
     )
   );

--- a/src/mappings/entities/mapAsset.ts
+++ b/src/mappings/entities/mapAsset.ts
@@ -88,6 +88,7 @@ export const createAssetTransaction = (
   return AssetTransaction.create({
     id: `${blockId}/${eventIdx}`,
     ...details,
+    // adding in fall back for `eventId` helps in identifying cases where utility.batchAtomic is used as extrinsic
     eventId: callToEventMappings[callId] || eventId || callToEventMappings['default'],
     eventIdx,
     extrinsicIdx: extrinsic?.idx,

--- a/src/mappings/entities/mapIdentities.ts
+++ b/src/mappings/entities/mapIdentities.ts
@@ -565,7 +565,9 @@ const handlePrimaryKeyUpdated = async (
   });
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { assets, portfolios, transactionGroups, transactions } = permissions;
+  const { assets, portfolios, transactionGroups, transactions } = permissions || {
+    transactionGroups: [],
+  };
 
   await Promise.all([
     createPermissions(

--- a/src/mappings/util.ts
+++ b/src/mappings/util.ts
@@ -479,7 +479,10 @@ export const bytesToString = (item: Codec): string => {
   if (isHex(value)) {
     return hexToString(value);
   }
-  return removeNullChars(value);
+  if (value) {
+    return removeNullChars(value);
+  }
+  return undefined;
 };
 
 export const getFundraiserDetails = (item: Codec): Omit<Attributes<Sto>, 'stoId' | 'name'> => {


### PR DESCRIPTION
### Description

For new fungible asset transfer events (since chain 6.x), the asset transaction entry was adding in the event as `Transfer` for Issued/Redeemed cases. Also for NFT related transactions `IssedNFT` and `RedeemedNFT` weren't being used. This fixes the logic to correctly populate the event value.

### Breaking Changes

NA

### JIRA Link

DA-967

### Checklist

- [ ] Updated the Readme.md (if required) ?
