### PR TITLE
fix: 🐛 Handle NFT holders in case of `nft.controller_transfer`

### DIFF
--- a/db/migrations/4_add_extrinsic_for_issued_txs.sql
+++ b/db/migrations/4_add_extrinsic_for_issued_txs.sql
@@ -1,0 +1,20 @@
+-- for older blocks, the extrinsic_idx in asset_transactions was not being populated. We use the events table to update the value for `Issued` event
+update 
+  asset_transactions ast
+set 
+  extrinsic_idx = e.extrinsic_idx
+from 
+  events e
+where 
+  e.block_id = ast.created_block_id
+  and e.event_idx = ast.event_idx
+  and ast.extrinsic_idx is null
+  and e.extrinsic_idx is not null;
+
+-- extrinsic_id mapping in events was not being populated correctly. We use the block_id and extrinsic_idx to update the missing values
+update 
+  events
+set 
+  extrinsic_id = block_id || '/' || extrinsic_idx
+where 
+  extrinsic_id is null;

--- a/src/mappings/entities/mapAsset.ts
+++ b/src/mappings/entities/mapAsset.ts
@@ -278,7 +278,13 @@ const handleDivisibilityChanged = async (blockId: string, params: Codec[]): Prom
   await asset.save();
 };
 
-const handleIssued = async ({ blockId, params, eventIdx, block }: HandlerArgs): Promise<void> => {
+const handleIssued = async ({
+  blockId,
+  params,
+  eventIdx,
+  block,
+  extrinsic,
+}: HandlerArgs): Promise<void> => {
   const [, rawTicker, rawBeneficiaryDid, rawAmount, rawFundingRound, rawTotalFundingAmount] =
     params;
 
@@ -304,6 +310,7 @@ const handleIssued = async ({ blockId, params, eventIdx, block }: HandlerArgs): 
     eventIdx,
     amount: issuedAmount,
     fundingRound,
+    extrinsicIdx: extrinsic?.idx,
     datetime: block.timestamp,
     createdBlockId: blockId,
     updatedBlockId: blockId,

--- a/src/mappings/entities/mapEvent.ts
+++ b/src/mappings/entities/mapEvent.ts
@@ -65,6 +65,11 @@ export function handleToolingEvent(
 
   const { claimExpiry, claimIssuer, claimScope, claimType } = extractClaimInfo(harvesterLikeArgs);
 
+  let extrinsicId: string;
+  if (extrinsic) {
+    extrinsicId = `${blockId}/${extrinsic?.idx}`;
+  }
+
   return Event.create({
     id: `${blockId}/${eventIdx}`,
     blockId,
@@ -85,6 +90,7 @@ export function handleToolingEvent(
     corporateActionTicker: extractCorporateActionTicker(harvesterLikeArgs),
     fundraiserOfferingAsset: extractOfferingAsset(harvesterLikeArgs),
     transferTo: extractTransferTo(harvesterLikeArgs),
+    extrinsicId,
   });
 }
 


### PR DESCRIPTION
### Description

In case of `ControllerTransfer` as the reason for `NFTPortfolioUpdate` event, asset transaction entry was being made but NFTHolder set of nft_ids was not getting updated. This handles the logic to  update the NFTHolders

### Breaking Changes

NA

### JIRA Link

DA-969

### Checklist

- [ ] Updated the Readme.md (if required) ?
