### PR TITLE
fix: 🐛 remove endBlock from project template

### DIFF
--- a/project.template.ts
+++ b/project.template.ts
@@ -88,7 +88,6 @@ const project: SubstrateProject = {
     {
       kind: SubstrateDatasourceKind.Runtime,
       startBlock: 1,
-      endBlock: 1,
       mapping: {
         file: './dist/index.js',
         handlers: [


### PR DESCRIPTION
### Description

endblock causes sync to stop at a block, which we do not want for our use case

Reference: https://github.com/subquery/documentation/pull/443/files#diff-60836b1220c109ec8d1a41d017d8e7d4d2b56dfa67140099a433e08907ba7626R226

### Breaking Changes

None

### JIRA Link

None

### Checklist

- [ ] Updated the Readme.md (if required) ?
