### PR TITLE
feat: 🎸 add ssh signing to the release bot configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,31 @@ jobs:
           cache: 'yarn'
       - name: install dependencies
         run: yarn --frozen-lockfile
+      - name: setup git
+        run: |
+          echo "$SSH_KEY_PRIVATE" | tr -d '\r' > /tmp/id_ed25519
+          echo $SSH_KEY_PUBLIC > /tmp/id_ed25519.pub
+          chmod 600 /tmp/id_ed25519
+          eval "$(ssh-agent -s)"
+          ssh-add /tmp/id_ed25519
+          git config --global gpg.format ssh
+          git config --global commit.gpgsign true
+          git config --global user.signingkey /tmp/id_ed25519.pub
+          mkdir -p ~/.config/git
+          echo "${{ vars.RB_EMAIL }} $SSH_KEY_PUBLIC" > ~/.config/git/allowed_signers
+          git config --global gpg.ssh.allowedSignersFile ~/.config/git/allowed_signers
+        shell: bash
+        env:
+          SSH_KEY_PRIVATE: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_KEY_PUBLIC: ${{ vars.SSH_PUBLIC_KEY }}
       - name: release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GIT_AUTHOR_NAME: ${{ vars.RB_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ vars.RB_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ vars.RB_COMMITTER_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ vars.RB_COMMITTER_EMAIL }}
         run: yarn semantic-release
+      - name: Clear SSH key
+        run: |
+          shred /tmp/id_ed25519


### PR DESCRIPTION
### Description

This changes the semantic bot release user to polymesh-bot and configures git to sign the release commits and tags.

### Breaking Changes

N/A

### JIRA Link

N/A

### Checklist

N/A
