### PR TITLE
fix: 🐛 Handle spec version logic correctly for private chain

### DIFF
--- a/src/mappings/entities/mapAsset.ts
+++ b/src/mappings/entities/mapAsset.ts
@@ -136,10 +136,13 @@ const handleAssetCreated = async (
   /**
    * Events from chain >= 6.0.0 doesn't have disable investor uniqueness value
    * It defaults to false from 6.0.0
+   *
+   * NOTE - for Polymesh Private SDK the spec version starts again from 1.0.0
    */
   let isUniquenessRequired = false;
 
-  if (block.specVersion >= 6000000) {
+  const specName = api.runtimeVersion.specName.toString();
+  if (block.specVersion >= 6000000 || specName === 'polymesh_private_dev') {
     [rawAssetName, rawIdentifiers, rawFundingRoundName] = rest;
   } else {
     [disableIu, rawAssetName, rawIdentifiers, rawFundingRoundName] = rest;

--- a/src/mappings/entities/mapPolyxTransaction.ts
+++ b/src/mappings/entities/mapPolyxTransaction.ts
@@ -79,7 +79,8 @@ const processTreasuryDisbursementArgs = async (args: HandlerArgs | Event, ss58Fo
     /**
      * Before spec version 500000, TreasuryDisbursement only had three params and there was not target account address in the event
      */
-    if (args.specVersionId < 5000000) {
+    const specName = api.runtimeVersion.specName.toString();
+    if (args.specVersionId < 5000000 && specName !== 'polymesh_private_dev') {
       [{ value: did }, { value: toDid }, { value: balance }] = attributes;
     } else {
       [{ value: did }, { value: toDid }, { value: toAddressHex }, { value: balance }] = attributes;
@@ -94,7 +95,9 @@ const processTreasuryDisbursementArgs = async (args: HandlerArgs | Event, ss58Fo
     }
   } else {
     let rawFromIdentity, rawToDid, rawTo, rawBalance;
-    if (args.block.specVersion < 5000000) {
+
+    const specName = api.runtimeVersion.specName.toString();
+    if (args.block.specVersion < 5000000 && specName !== 'polymesh_private_dev') {
       [rawFromIdentity, rawToDid, rawBalance] = args.params;
     } else {
       [rawFromIdentity, rawToDid, rawTo, rawBalance] = args.params;

--- a/src/mappings/entities/mapSettlement.ts
+++ b/src/mappings/entities/mapSettlement.ts
@@ -187,8 +187,11 @@ const handleInstructionCreated = async (args: HandlerArgs): Promise<void> => {
 
   /**
    * Events from 6.0.0 chain were updated to support NFT and OffChain instructions
+   *
+   * NOTE - For Polymesh private, the spec version starts from 1.0.0
    */
-  if (block.specVersion >= 6000000) {
+  const specName = api.runtimeVersion.specName.toString();
+  if (block.specVersion >= 6000000 || specName === 'polymesh_private_dev') {
     legs = getSettlementLeg(rawLegs);
   } else {
     legs = getLegsValue(rawLegs);

--- a/src/mappings/entities/mapStatistics.ts
+++ b/src/mappings/entities/mapStatistics.ts
@@ -379,7 +379,8 @@ const handleAssetRedeemed = async (blockId: string, params: Codec[], block: Subs
   const ticker = serializeTicker(rawTicker);
 
   const specVersion = block.specVersion;
-  if (specVersion < transferRestrictionSpecVersion) {
+  const specName = api.runtimeVersion.specName.toString();
+  if (specVersion < transferRestrictionSpecVersion && specName !== 'polymesh_private_dev') {
     const asset = await Asset.getByTicker(ticker);
     if (asset.totalSupply === BigInt(0)) {
       await StatType.remove(`${ticker}/Count`);


### PR DESCRIPTION
### Description

Since the spec version value for PP chain was reset to 1000000, the logic around a few features got botched. Using the specName from runtimeVersion, logic has been modified to fix the features.

### Breaking Changes

NA

### JIRA Link

DA-1154

### Checklist

- [ ] Updated the Readme.md (if required) ?
