### PR TITLE
feat: 🎸 improve block process time for large batch transactions

### DIFF
--- a/src/mappings/entities/mapAsset.ts
+++ b/src/mappings/entities/mapAsset.ts
@@ -615,9 +615,6 @@ const handlePreApprovedAsset = async ({ params, blockId }: HandlerArgs) => {
   const identityId = getTextValue(params[0]);
   const assetId = serializeTicker(params[1]);
 
-  logger.info(identityId);
-  logger.info(assetId);
-
   await AssetPreApproval.create({
     id: `${assetId}/${identityId}`,
     assetId,

--- a/src/mappings/entities/mapExtrinsic.ts
+++ b/src/mappings/entities/mapExtrinsic.ts
@@ -1,15 +1,14 @@
 import { hexStripPrefix } from '@polkadot/util';
 import { SubstrateBlock, SubstrateExtrinsic } from '@subql/types';
 import { CallIdEnum, Extrinsic, ModuleIdEnum } from '../../types';
-import { serializeCallArgsLikeHarvester } from '../serializeLikeHarvester';
-import { camelToSnakeCase, logFoundType } from '../util';
+import { camelToSnakeCase } from '../util';
 
 export function createExtrinsic(extrinsic: SubstrateExtrinsic): Extrinsic {
   const blockId = extrinsic.block.block.header.number.toString();
   const extrinsicIdx = extrinsic.idx;
   const signedbyAddress = !extrinsic.extrinsic.signer.isEmpty;
   const address = signedbyAddress ? extrinsic.extrinsic.signer.toString() : null;
-  const params = serializeCallArgsLikeHarvester(extrinsic.extrinsic, logFoundType);
+  const paramsTxt = JSON.stringify((extrinsic.extrinsic.toHuman() as any).method.args);
 
   return Extrinsic.create({
     id: `${blockId}/${extrinsicIdx}`,
@@ -19,7 +18,7 @@ export function createExtrinsic(extrinsic: SubstrateExtrinsic): Extrinsic {
     signed: extrinsic.extrinsic.isSigned ? 1 : 0,
     moduleId: extrinsic.extrinsic.method.section.toLowerCase() as ModuleIdEnum,
     callId: camelToSnakeCase(extrinsic.extrinsic.method.method) as CallIdEnum,
-    paramsTxt: JSON.stringify(params),
+    paramsTxt,
     success: extrinsic.success ? 1 : 0,
     signedbyAddress: signedbyAddress ? 1 : 0,
     address,


### PR DESCRIPTION
### Description

improves block processing time for large batch transactions by removing serializeCallArgsLikeHarvester when saving extrinsics. Before a batch of 400 issue NFTs would take minutes to process, with this change it now takes seconds. It does change the format of `Extrinsic.params` and `Extrinsic.paramsTxt`. If you are using these fields a full resync is reccomended, and to update any code accessing any nested params. It still returns a JSON serializable string.

### Breaking Changes

BREAKING CHANGE: 🧨 Extrinsic.params and Extrinsic.paramsTxt have updated their JSON format

### JIRA Link

✅ Closes: [DA-1162](https://polymesh.atlassian.net/browse/DA-1162)

### Checklist

- [ ] Updated the Readme.md (if required) ?


**Example**

Previous params:
```json
[{"name":"dest","value":"0xda7743ce00715c8076b80c16aa04632a90909c259c529cfdd4cad07524c80a71"},{"name":"value","value":1}]
```

New params:

```json
{"dest":{"Id":"5CuBMKLnPtNh3RFagEbFpBqz3E68RUczQBPz26n21poTCcxT"},"value":"1.0000 µPOLYX"}
```


[DA-1162]: https://polymesh.atlassian.net/browse/DA-1162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ