### PR TITLE
refactor: 💡 improve sync performance on large batches

### DIFF
--- a/src/mappings/entities/mapBlock.ts
+++ b/src/mappings/entities/mapBlock.ts
@@ -1,7 +1,7 @@
 import { SubstrateBlock } from '@subql/types';
 import { Block } from '../../types';
 
-export const mapBlock = async (block: SubstrateBlock): Promise<Block> => {
+export const mapBlock = (block: SubstrateBlock): Block => {
   const header = block.block.header;
   const blockId = header.number.toNumber();
   const countExtrinsics = block.block.extrinsics?.length;

--- a/src/mappings/mappingHandlers.ts
+++ b/src/mappings/mappingHandlers.ts
@@ -9,6 +9,7 @@ import { logError } from './util';
 import migrationHandlers from './migrations/migrationHandlers';
 
 let lastBlockHash = '';
+let lastEventIdx = -1;
 export async function handleEvent(substrateEvent: SubstrateEvent): Promise<void> {
   const header = substrateEvent.block.block.header;
   const blockId = header.number.toNumber();
@@ -40,11 +41,13 @@ export async function handleEvent(substrateEvent: SubstrateEvent): Promise<void>
   const blockHash = substrateEvent.block.hash.toHex();
   if (blockHash !== lastBlockHash) {
     lastBlockHash = blockHash;
-    const block = await mapBlock(substrateEvent.block);
+    lastEventIdx = -1;
+    const block = mapBlock(substrateEvent.block);
     promises.push(block.save());
   }
 
-  if (substrateEvent.extrinsic) {
+  if (substrateEvent?.extrinsic?.idx > lastEventIdx) {
+    lastEventIdx = substrateEvent?.extrinsic?.idx;
     const extrinsic = createExtrinsic(substrateEvent.extrinsic);
     promises.push(extrinsic.save());
   }


### PR DESCRIPTION
### Description

skip recreating already indexed extrinsics

locally, reduces staging block 1010260 sync time from ~33 seconds to ~10 seconds.

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
