### PR TITLE
feat: 🎸 add updated_at time version for SDK backwards support

### DIFF
--- a/db/compat.sql
+++ b/db/compat.sql
@@ -60,3 +60,6 @@ BEGIN
         EXECUTE format('ALTER TABLE %I ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;', tbl_name);
     END LOOP;
 END $$;
+
+-- Add `updated_at` to subquery_versions for SDK <= v24.5.6 support
+ALTER TABLE subquery_versions ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;


### PR DESCRIPTION
### Description

add legacy `updated_at` field to `subquery_versions` to support older SDK versions.

This lets us go ahead with SQ update without forcing an SDK upgrade for now.

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
