### PR TITLE
fix: 🐛 Correctly map claim data for `StatTypesAdded` event

### DIFF
--- a/db/migrations/1_alter_stat_type.sql
+++ b/db/migrations/1_alter_stat_type.sql
@@ -1,0 +1,15 @@
+ALTER TABLE stat_types 
+ADD COLUMN IF NOT EXISTS custom_claim_type_id TEXT;
+
+-- add foreign key constraint only if historical state is not enabled
+DO $$
+BEGIN
+    IF NOT EXISTS (select 1 from _metadata where key = 'historicalStateEnabled' and value = 'true') then
+        ALTER TABLE stat_types 
+            DROP CONSTRAINT IF EXISTS "stat_types_custom_claim_type_id_fkey";
+        ALTER TABLE stat_types
+            ADD CONSTRAINT "stat_types_custom_claim_type_id_fkey"
+            FOREIGN KEY (custom_claim_type_id) REFERENCES custom_claim_types(id) ON UPDATE CASCADE ON DELETE SET NULL DEFERRABLE;
+    END IF;
+END
+$$;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymesh-subquery",
-  "version": "15.0.0",
+  "version": "15.0.1-alpha.1",
   "author": "Polymesh Association",
   "license": "Apache-2.0",
   "description": "A Polymesh Chain Indexer, providing a GraphQL interface",

--- a/schema.graphql
+++ b/schema.graphql
@@ -2043,6 +2043,7 @@ type StatType @entity {
   asset: Asset!
   opType: StatOpTypeEnum!
   claimType: ClaimTypeEnum
+  customClaimType: CustomClaimType
   claimIssuer: Identity
   createdBlock: Block!
   updatedBlock: Block!


### PR DESCRIPTION
### Description

Testnet broke on adding claim issuer info while setting stat types - https://polymesh-testnet.subscan.io/block/14582125.
Data was incorrectly mapped without considering object type property for claim type. 

Also, claim type ID was not getting tracked (in case the claim type was Custom). This adds the customClaimType attribute as well 

### Breaking Changes

NA

### JIRA Link

DA-1265

### Checklist

- [ ] Updated the Readme.md (if required) ?
