### PR TITLE
Add new events for 7.x chain and some other fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymesh-subquery",
-  "version": "16.0.1",
+  "version": "16.1.0",
   "author": "Polymesh Association",
   "license": "Apache-2.0",
   "description": "A Polymesh Chain Indexer, providing a GraphQL interface",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@polkadot/api": "^11.2.1",
     "@polkadot/types-support": "^11.2.1",
-    "@polymeshassociation/polymesh-types": "^5.9.0",
+    "@polymeshassociation/polymesh-types": "^5.14.0",
     "@subql/cli": "4.14.0",
     "@subql/types": "3.6.1",
     "@subql/types-core": "^0.7.0",

--- a/project.ts
+++ b/project.ts
@@ -46,6 +46,7 @@ const filters = {
     AssetMediatorsAdded: ['handleAssetMediatorsAdded'],
     AssetMediatorsRemoved: ['handleAssetMediatorsRemoved'],
     TickerLinkedToAsset: ['handleTickerLinkedToAsset'],
+    TickerUnlinkedFromAsset: ['handleTickerUnlinkedFromAsset'],
   },
   balances: {
     AccountBalanceBurned: ['handleBalanceBurned'],

--- a/schema.graphql
+++ b/schema.graphql
@@ -357,6 +357,7 @@ enum EventIdEnum {
   AssetMediatorsAdded
   SetAssetMediators # This can be removed, `AssetMediatorsAdded` is emitted instead
   AssetMediatorsRemoved
+  TickerUnlinkedFromAsset
 
   ## capitaldistribution ##
   Created
@@ -869,6 +870,7 @@ enum CallIdEnum {
   join_identity
   reject
   remove_admin_via_admin
+  remove_admin
   remove_multisig_signers_via_admin
   remove_multisig_signers
   remove_payer
@@ -1027,6 +1029,7 @@ enum CallIdEnum {
   add_mandatory_mediators
   remove_mandatory_mediators
   link_ticker_to_asset_id
+  unlink_ticker_from_asset_id
 
   ## capitaldistribution ##
   distribute

--- a/src/mappings/entities/assets/mapAsset.ts
+++ b/src/mappings/entities/assets/mapAsset.ts
@@ -188,7 +188,7 @@ export const handleAssetCreated = async (event: SubstrateEvent): Promise<void> =
   }
 
   await Asset.create({
-    id: getAssetId(rawAssetId, block),
+    id: await getAssetId(rawAssetId, block),
     ticker,
     name,
     type: assetType,
@@ -212,7 +212,7 @@ export const handleAssetRenamed = async (event: SubstrateEvent): Promise<void> =
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId, rawName] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
 
   const asset = await getAsset(assetId);
   asset.name = bytesToString(rawName);
@@ -225,7 +225,7 @@ export const handleFundingRoundSet = async (event: SubstrateEvent): Promise<void
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId, rawFundingRound] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
 
   const asset = await getAsset(assetId);
 
@@ -239,7 +239,7 @@ export const handleDocumentAdded = async (event: SubstrateEvent): Promise<void> 
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId, rawDocId, rawDoc] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const documentId = getNumberValue(rawDocId);
   const docDetails = getDocValue(rawDoc);
 
@@ -259,7 +259,7 @@ export const handleDocumentRemoved = async (event: SubstrateEvent): Promise<void
   const { params, block } = extractArgs(event);
   const [, rawAssetId, rawDocId] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const documentId = getNumberValue(rawDocId);
 
   await AssetDocument.remove(`${assetId}/${documentId}`);
@@ -269,7 +269,7 @@ export const handleIdentifiersUpdated = async (event: SubstrateEvent): Promise<v
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId, rawIdentifiers] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
 
   const asset = await getAsset(assetId);
   asset.identifiers = getSecurityIdentifiers(rawIdentifiers);
@@ -282,7 +282,7 @@ export const handleDivisibilityChanged = async (event: SubstrateEvent): Promise<
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
 
   const asset = await getAsset(assetId);
   asset.isDivisible = true;
@@ -297,7 +297,7 @@ export const handleIssued = async (event: SubstrateEvent): Promise<void> => {
     params;
 
   const issuerDid = getTextValue(rawBeneficiaryDid);
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const issuedAmount = getBigIntValue(rawAmount);
   const fundingRound = bytesToString(rawFundingRound);
   const totalFundingAmount = getBigIntValue(rawTotalFundingAmount);
@@ -347,7 +347,7 @@ export const handleRedeemed = async (event: SubstrateEvent): Promise<void> => {
   const [, rawAssetId, rawBeneficiaryDid, rawAmount] = params;
 
   const issuerDid = getTextValue(rawBeneficiaryDid);
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const issuedAmount = getBigIntValue(rawAmount);
 
   const asset = await getAsset(assetId);
@@ -367,7 +367,7 @@ export const handleFrozen = async (event: SubstrateEvent): Promise<void> => {
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
 
   const asset = await getAsset(assetId);
   asset.isFrozen = true;
@@ -380,7 +380,7 @@ export const handleUnfrozen = async (event: SubstrateEvent): Promise<void> => {
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
 
   const asset = await getAsset(assetId);
   asset.isFrozen = false;
@@ -394,7 +394,7 @@ export const handleAssetOwnershipTransferred = async (event: SubstrateEvent): Pr
 
   const [to, rawAssetId] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
 
   const asset = await getAsset(assetId);
   asset.ownerId = getTextValue(to);
@@ -408,7 +408,7 @@ export const handleAssetTransfer = async (event: SubstrateEvent): Promise<void> 
   const [, rawAssetId, rawFromPortfolio, rawToPortfolio, rawAmount] = params;
   const { identityId: fromDid, number: fromPortfolioNumber } = getPortfolioValue(rawFromPortfolio);
   const { identityId: toDid, number: toPortfolioNumber } = getPortfolioValue(rawToPortfolio);
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const transferAmount = getBigIntValue(rawAmount);
 
   let fromPortfolioId = `${fromDid}/${fromPortfolioNumber}`;
@@ -483,7 +483,7 @@ export const handleAssetBalanceUpdated = async (event: SubstrateEvent): Promise<
 
   let fromPortfolioNumber: number, toPortfolioNumber: number;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const asset = await getAsset(assetId);
 
   let fromPortfolioId: string;
@@ -593,7 +593,7 @@ export const handleAssetBalanceUpdated = async (event: SubstrateEvent): Promise<
 export const handleAssetMediatorsAdded = async (event: SubstrateEvent): Promise<void> => {
   const { params, blockId, block } = extractArgs(event);
   const addedById = getTextValue(params[0]);
-  const assetId = getAssetId(params[1], block);
+  const assetId = await getAssetId(params[1], block);
   const mediators = getStringArrayValue(params[2]);
 
   const createPromises = mediators.map(mediator =>
@@ -612,7 +612,7 @@ export const handleAssetMediatorsAdded = async (event: SubstrateEvent): Promise<
 
 export const handleAssetMediatorsRemoved = async (event: SubstrateEvent): Promise<void> => {
   const { params, block } = extractArgs(event);
-  const assetId = getAssetId(params[1], block);
+  const assetId = await getAssetId(params[1], block);
   const mediators = getStringArrayValue(params[2]);
 
   await Promise.all(
@@ -623,7 +623,7 @@ export const handleAssetMediatorsRemoved = async (event: SubstrateEvent): Promis
 export const handlePreApprovedAsset = async (event: SubstrateEvent): Promise<void> => {
   const { params, blockId, block } = extractArgs(event);
   const identityId = getTextValue(params[0]);
-  const assetId = getAssetId(params[1], block);
+  const assetId = await getAssetId(params[1], block);
 
   await AssetPreApproval.create({
     id: `${assetId}/${identityId}`,
@@ -638,7 +638,7 @@ export const handleRemovePreApprovedAsset = async (event: SubstrateEvent): Promi
   const { params, block } = extractArgs(event);
 
   const identityId = getTextValue(params[0]);
-  const assetId = getAssetId(params[1], block);
+  const assetId = await getAssetId(params[1], block);
 
   await AssetPreApproval.remove(`${assetId}/${identityId}`);
 };

--- a/src/mappings/entities/assets/mapAsset.ts
+++ b/src/mappings/entities/assets/mapAsset.ts
@@ -648,11 +648,26 @@ export const handleTickerLinkedToAsset = async (event: SubstrateEvent): Promise<
 
   const [, rawTicker, rawAssetId] = params;
   const ticker = serializeTicker(rawTicker);
-  const assetId = rawAssetId.toString();
+  const assetId = getTextValue(rawAssetId);
   const asset = await getAsset(assetId);
 
   asset.ticker = ticker;
   asset.updatedBlockId = blockId;
 
   await asset.save();
+};
+
+export const handleTickerUnlinkedFromAsset = async (event: SubstrateEvent): Promise<void> => {
+  const { params, blockId } = extractArgs(event);
+
+  const [, rawTicker, rawAssetId] = params;
+  const ticker = serializeTicker(rawTicker);
+  const assetId = getTextValue(rawAssetId);
+  const asset = await getAsset(assetId);
+
+  if (asset.ticker === ticker) {
+    asset.ticker = undefined;
+    asset.updatedBlockId = blockId;
+    await asset.save();
+  }
 };

--- a/src/mappings/entities/assets/mapCompliance.ts
+++ b/src/mappings/entities/assets/mapCompliance.ts
@@ -14,7 +14,7 @@ export const handleAssetCompliancePaused = async (event: SubstrateEvent): Promis
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
 
   const asset = await getAsset(assetId);
   asset.isCompliancePaused = true;
@@ -27,7 +27,7 @@ export const handleAssetComplianceResumed = async (event: SubstrateEvent): Promi
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
 
   const asset = await getAsset(assetId);
   asset.isCompliancePaused = false;
@@ -40,7 +40,7 @@ export const handleComplianceReset = async (event: SubstrateEvent): Promise<void
   const { params, block } = extractArgs(event);
   const [, rawAssetId] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
 
   const complianceRequirements = await Compliance.getByAssetId(assetId);
 
@@ -61,7 +61,7 @@ export const handleComplianceCreated = async (event: SubstrateEvent): Promise<vo
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId, rawCompliance] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const { complianceId, data } = getComplianceValue(rawCompliance);
 
   await createCompliance(assetId, complianceId, data, blockId);
@@ -71,7 +71,7 @@ export const handleComplianceReplaced = async (event: SubstrateEvent): Promise<v
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId, rawCompliances] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
 
   const existingCompliances = await Compliance.getByAssetId(assetId);
 
@@ -89,7 +89,7 @@ export const handleComplianceRemoved = async (event: SubstrateEvent): Promise<vo
   const { params, block } = extractArgs(event);
   const [, rawAssetId, rawId] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const complianceId = getNumberValue(rawId);
 
   await Compliance.remove(`${assetId}/${complianceId}`);
@@ -101,7 +101,7 @@ export const handleTrustedDefaultClaimIssuerAdded = async (
   const { params, eventIdx, blockId, block } = extractArgs(event);
 
   const [, rawAssetId, rawIssuer] = params;
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const issuer = (rawIssuer as unknown as { issuer: Codec }).issuer.toString();
 
   await TrustedClaimIssuer.create({
@@ -120,7 +120,7 @@ export const handleTrustedDefaultClaimIssuerRemoved = async (
   const { params, block } = extractArgs(event);
 
   const [, rawAssetId, rawIdentity] = params;
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const issuer = getTextValue(rawIdentity);
   await TrustedClaimIssuer.remove(`${assetId}/${issuer}`);
 };

--- a/src/mappings/entities/assets/mapCorporateActions.ts
+++ b/src/mappings/entities/assets/mapCorporateActions.ts
@@ -7,7 +7,7 @@ export const handleDistributionCreated = async (event: SubstrateEvent): Promise<
   const { params, blockId, block } = extractArgs(event);
   const [rawDid, rawCaId, rawDistribution] = params;
 
-  const { localId, assetId } = getCaIdValue(rawCaId, block);
+  const { localId, assetId } = await getCaIdValue(rawCaId, block);
   const distributionDetails = getDistributionValue(rawDistribution);
 
   await Distribution.create({
@@ -26,7 +26,7 @@ export const handleDistributionRemoved = async (event: SubstrateEvent): Promise<
   const { params, block } = extractArgs(event);
   const [, rawCaId] = params;
 
-  const { localId, assetId } = getCaIdValue(rawCaId, block);
+  const { localId, assetId } = await getCaIdValue(rawCaId, block);
 
   await Distribution.remove(`${assetId}/${localId}`);
 };
@@ -36,7 +36,7 @@ export const handleBenefitClaimed = async (event: SubstrateEvent): Promise<void>
   const [, rawClaimantDid, rawCaId, , rawAmount, rawTax] = params;
 
   const targetId = getTextValue(rawClaimantDid);
-  const { localId, assetId } = getCaIdValue(rawCaId, block);
+  const { localId, assetId } = await getCaIdValue(rawCaId, block);
   const amount = getBigIntValue(rawAmount);
   const tax = getBigIntValue(rawTax);
 
@@ -67,7 +67,7 @@ export const handleReclaimed = async (event: SubstrateEvent): Promise<void> => {
   const [rawEventDid, rawCaId, rawAmount] = params;
 
   const targetId = getTextValue(rawEventDid);
-  const { localId, assetId } = getCaIdValue(rawCaId, block);
+  const { localId, assetId } = await getCaIdValue(rawCaId, block);
   const amount = getBigIntValue(rawAmount);
 
   await DistributionPayment.create({

--- a/src/mappings/entities/assets/mapNfts.ts
+++ b/src/mappings/entities/assets/mapNfts.ts
@@ -40,7 +40,7 @@ export const getNftHolder = async (
 export const handleNftCollectionCreated = async (event: SubstrateEvent): Promise<void> => {
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId] = params;
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const asset = await getAsset(assetId);
 
   asset.isNftCollection = true;
@@ -71,7 +71,7 @@ export const handleNftPortfolioUpdates = async (event: SubstrateEvent): Promise<
   const reason = getFirstKeyFromJson(rawUpdateReason);
   const value = getFirstValueFromJson(rawUpdateReason);
 
-  const { assetId, ids } = getNftId(rawNftId, block);
+  const { assetId, ids } = await getNftId(rawNftId, block);
 
   const asset = await getAsset(assetId);
   asset.updatedBlockId = blockId;

--- a/src/mappings/entities/assets/mapStatistics.ts
+++ b/src/mappings/entities/assets/mapStatistics.ts
@@ -19,7 +19,10 @@ import {
 } from '../../../utils';
 import { Attributes, extractArgs } from '../common';
 
-export const getAssetIdForStatisticsEvent = (item: Codec, block: SubstrateBlock): string => {
+export const getAssetIdForStatisticsEvent = (
+  item: Codec,
+  block: SubstrateBlock
+): Promise<string> => {
   let assetId: string;
   if (block.specVersion < 7000000) {
     const scope = JSON.parse(item.toString());
@@ -186,7 +189,7 @@ export const handleStatTypeAdded = async (event: SubstrateEvent): Promise<void> 
 
   const [, rawStatisticsScope, rawStatType] = params;
 
-  const assetId = getAssetIdForStatisticsEvent(rawStatisticsScope, block);
+  const assetId = await getAssetIdForStatisticsEvent(rawStatisticsScope, block);
   const statTypes = getStatTypes(rawStatType, block);
 
   const promises = [];
@@ -205,7 +208,7 @@ export const handleStatTypeRemoved = async (event: SubstrateEvent): Promise<void
 
   const [, rawStatisticsScope, rawStatType] = params;
 
-  const assetId = getAssetIdForStatisticsEvent(rawStatisticsScope, block);
+  const assetId = await getAssetIdForStatisticsEvent(rawStatisticsScope, block);
   const statTypes = getStatTypes(rawStatType, block);
 
   await Promise.all(
@@ -221,7 +224,7 @@ export const handleSetTransferCompliance = async (event: SubstrateEvent): Promis
 
   const [, rawStatisticsScope, rawTransferConditions] = params;
 
-  const assetId = getAssetIdForStatisticsEvent(rawStatisticsScope, block);
+  const assetId = await getAssetIdForStatisticsEvent(rawStatisticsScope, block);
 
   const transferConditions = getTransferConditions(rawTransferConditions, assetId);
 
@@ -266,7 +269,7 @@ export const handleStatisticExemptionsAdded = async (event: SubstrateEvent): Pro
 
   const [, rawExemptKey, rawExemptions] = params;
 
-  const exemptKey = getExemptKeyValue(rawExemptKey, block);
+  const exemptKey = await getExemptKeyValue(rawExemptKey, block);
   const exemptedEntities = rawExemptions.toJSON() as string[];
 
   const { assetId, opType, claimType } = exemptKey;
@@ -300,7 +303,7 @@ export const handleStatisticExemptionsRemoved = async (event: SubstrateEvent): P
 
   const [, rawExemptKey, rawExemptions] = params;
 
-  const { assetId, opType, claimType } = getExemptKeyValue(rawExemptKey, block);
+  const { assetId, opType, claimType } = await getExemptKeyValue(rawExemptKey, block);
   const exemptedEntities = rawExemptions.toJSON() as string[];
 
   await Promise.all(
@@ -315,7 +318,7 @@ export const handleStatisticTransferManagerAdded = async (event: SubstrateEvent)
 
   const [, rawAssetId, rawManager] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const { type } = getTransferManagerValue(rawManager);
 
   if (type === TransferRestrictionTypeEnum.Percentage) {
@@ -333,7 +336,7 @@ export const handleTransferManagerExemptionsAdded = async (
 
   const [, rawAssetId, rawAgentGroup, rawExemptions] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const { type } = getTransferManagerValue(rawAgentGroup);
   const parsedExemptions = getExemptionsValue(rawExemptions);
 
@@ -382,7 +385,7 @@ export const handleTransferManagerExemptionsRemoved = async (
 
   const [, rawAssetId, rawAgentGroup, rawExemptions] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const transferManagerValue = getTransferManagerValue(rawAgentGroup);
   const parsedExemptions = getExemptionsValue(rawExemptions);
 
@@ -408,7 +411,7 @@ export const handleAssetIssuedStatistics = async (event: SubstrateEvent): Promis
 
   const [, rawAssetId] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const { specVersion } = block;
   if (specVersion < transferRestrictionSpecVersion) {
     await upsertStatType(
@@ -422,7 +425,7 @@ export const handleAssetRedeemedStatistics = async (event: SubstrateEvent): Prom
   const { params, block } = extractArgs(event);
 
   const [, rawAssetId] = params;
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
 
   const specVersion = block.specVersion;
   const specName = api.runtimeVersion.specName.toString();

--- a/src/mappings/entities/assets/mapTransferManager.ts
+++ b/src/mappings/entities/assets/mapTransferManager.ts
@@ -18,7 +18,7 @@ export const handleTransferManagerAdded = async (event: SubstrateEvent): Promise
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId, rawManager] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const { type, value } = getTransferManagerValue(rawManager);
   const id = `${assetId}/${type}/${value}`;
 
@@ -37,7 +37,7 @@ export const handleTransferManagerRemoved = async (event: SubstrateEvent): Promi
   const { params, block } = extractArgs(event);
   const [, rawAssetId, rawManager] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const { type, value } = getTransferManagerValue(rawManager);
   const id = `${assetId}/${type}/${value}`;
 
@@ -48,7 +48,7 @@ export const handleExemptionsAdded = async (event: SubstrateEvent): Promise<void
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId, rawAgentGroup, rawExemptions] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const transferManagerValue = getTransferManagerValue(rawAgentGroup);
   const parsedExemptions = getExemptionsValue(rawExemptions);
 
@@ -68,7 +68,7 @@ export const handleExemptionsRemoved = async (event: SubstrateEvent): Promise<vo
   const { params, blockId, block } = extractArgs(event);
   const [, rawAssetId, rawAgentGroup, rawExemptions] = params;
 
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const transferManagerValue = getTransferManagerValue(rawAgentGroup);
   const parsedExemptions = getExemptionsValue(rawExemptions);
 

--- a/src/mappings/entities/externalAgents/mapExternalAgent.ts
+++ b/src/mappings/entities/externalAgents/mapExternalAgent.ts
@@ -6,7 +6,7 @@ import { extractArgs } from '../common';
 export const handleExternalAgentAdded = async (event: SubstrateEvent): Promise<void> => {
   const { params, blockId, eventIdx, block } = extractArgs(event);
   const callerId = getTextValue(params[0]);
-  const assetId = getAssetId(params[1], block);
+  const assetId = await getAssetId(params[1], block);
 
   await TickerExternalAgent.create({
     id: `${assetId}/${callerId}`,
@@ -22,6 +22,6 @@ export const handleExternalAgentAdded = async (event: SubstrateEvent): Promise<v
 export const handleExternalAgentRemoved = async (event: SubstrateEvent): Promise<void> => {
   const { params, block } = extractArgs(event);
   const agent = params[2].toString();
-  const assetId = getAssetId(params[1], block);
+  const assetId = await getAssetId(params[1], block);
   await TickerExternalAgent.remove(`${assetId}/${agent}`);
 };

--- a/src/mappings/entities/externalAgents/mapExternalAgentAction.ts
+++ b/src/mappings/entities/externalAgents/mapExternalAgentAction.ts
@@ -152,7 +152,7 @@ class ExternalAgentEventsManager {
       .add(
         ModuleIdEnum.statistics,
         [EventIdEnum.AssetStatsUpdated, EventIdEnum.StatTypesAdded, EventIdEnum.StatTypesRemoved],
-        async (params, block) => getAssetIdForStatisticsEvent(params[1], block)
+        async (params, block) => await getAssetIdForStatisticsEvent(params[1], block)
       )
       .add(
         ModuleIdEnum.statistics,
@@ -160,7 +160,7 @@ class ExternalAgentEventsManager {
           EventIdEnum.TransferConditionExemptionsAdded,
           EventIdEnum.TransferConditionExemptionsRemoved,
         ],
-        async (params, block) => getExemptKeyValue(params[1], block).assetId
+        async (params, block) => (await getExemptKeyValue(params[1], block)).assetId
       )
       .add(
         ModuleIdEnum.corporateaction,

--- a/src/mappings/entities/externalAgents/mapExternalAgentHistory.ts
+++ b/src/mappings/entities/externalAgents/mapExternalAgentHistory.ts
@@ -12,7 +12,7 @@ export const handleGroupCreated = async (event: SubstrateEvent): Promise<void> =
 
   const group = params[2].toJSON();
   const permissions = JSON.stringify(params[3].toJSON());
-  const assetId = getAssetId(params[1], block);
+  const assetId = await getAssetId(params[1], block);
 
   await AgentGroupEntity.create({
     id: `${assetId}/${group}`,
@@ -27,7 +27,7 @@ export const handleGroupPermissionsUpdated = async (event: SubstrateEvent): Prom
 
   const group = params[2].toJSON();
   const permissions = JSON.stringify(params[3].toJSON());
-  const assetId = getAssetId(params[1], block);
+  const assetId = await getAssetId(params[1], block);
 
   const ag = await AgentGroupEntity.get(`${assetId}/${group}`);
   ag.permissions = permissions;
@@ -57,7 +57,7 @@ export const handleAgentAdded = async (event: SubstrateEvent): Promise<void> => 
   const { params, blockId, eventIdx, block } = extractArgs(event);
 
   const did = params[0].toString();
-  const assetId = getAssetId(params[1], block);
+  const assetId = await getAssetId(params[1], block);
 
   const group = params[2].toJSON() as AgentGroup;
 
@@ -77,7 +77,7 @@ export const handleGroupChanged = async (event: SubstrateEvent): Promise<void> =
 
   const did = params[2].toString();
   const group = params[3].toJSON() as AgentGroup;
-  const assetId = getAssetId(params[1], block);
+  const assetId = await getAssetId(params[1], block);
 
   const promises = [
     removeMember(did, assetId),
@@ -102,7 +102,7 @@ export const handleGroupChanged = async (event: SubstrateEvent): Promise<void> =
 export async function handleAgentRemoved(event: SubstrateEvent): Promise<void> {
   const { params, blockId, eventIdx, block } = extractArgs(event);
   const did = params[2].toString();
-  const assetId = getAssetId(params[1], block);
+  const assetId = await getAssetId(params[1], block);
 
   const promises = [
     removeMember(did, assetId),

--- a/src/mappings/entities/identities/mapClaim.ts
+++ b/src/mappings/entities/identities/mapClaim.ts
@@ -158,7 +158,7 @@ export const handleDidRegistered = async (event: SubstrateEvent): Promise<void> 
   const { params, blockId, block } = extractArgs(event);
 
   const target = getTextValue(params[0]);
-  const assetId = getAssetId(params[1], block);
+  const assetId = await getAssetId(params[1], block);
 
   await handleScopes(blockId, target, assetId);
 };

--- a/src/mappings/entities/identities/mapPortfolio.ts
+++ b/src/mappings/entities/identities/mapPortfolio.ts
@@ -15,7 +15,6 @@ import {
   getPortfolioValue,
   getSignerAddress,
   getTextValue,
-  hexToString,
 } from '../../../utils';
 import { Attributes, extractArgs } from '../common';
 import { createIdentityIfNotExists } from './mapIdentities';
@@ -205,7 +204,7 @@ export const handleFundsMovedBetweenPortfolios = async (event: SubstrateEvent): 
       ids: number[];
     };
     nftIds = description.ids.map(id => BigInt(id));
-    assetId = hexToString(description.ticker ?? description.assetId);
+    assetId = getAssetId(description.ticker ?? description.assetId, block);
     type = PortfolioMovementTypeEnum.NonFungible;
   }
 

--- a/src/mappings/entities/identities/mapPortfolio.ts
+++ b/src/mappings/entities/identities/mapPortfolio.ts
@@ -159,7 +159,7 @@ export const handlePortfolioMovement = async (event: SubstrateEvent): Promise<vo
   const address = getSignerAddress(extrinsic);
   const from = getPortfolioValue(rawFromPortfolio);
   const to = getPortfolioValue(rawToPortfolio);
-  const assetId = getAssetId(rawAssetId, block);
+  const assetId = await getAssetId(rawAssetId, block);
   const amount = getBigIntValue(rawAmount);
   const memo = bytesToString(rawMemo);
 
@@ -194,7 +194,7 @@ export const handleFundsMovedBetweenPortfolios = async (event: SubstrateEvent): 
       assetId?: string;
       amount: number;
     };
-    assetId = getAssetId(description.ticker ?? description.assetId, block);
+    assetId = await getAssetId(description.ticker ?? description.assetId, block);
     amount = BigInt(description.amount);
     type = PortfolioMovementTypeEnum.Fungible;
   } else if (assetType === 'nonFungible') {
@@ -204,7 +204,7 @@ export const handleFundsMovedBetweenPortfolios = async (event: SubstrateEvent): 
       ids: number[];
     };
     nftIds = description.ids.map(id => BigInt(id));
-    assetId = getAssetId(description.ticker ?? description.assetId, block);
+    assetId = await getAssetId(description.ticker ?? description.assetId, block);
     type = PortfolioMovementTypeEnum.NonFungible;
   }
 

--- a/src/mappings/entities/stos/mapSto.ts
+++ b/src/mappings/entities/stos/mapSto.ts
@@ -43,7 +43,7 @@ export const handleStoClosed = async (event: SubstrateEvent): Promise<void> => {
 const handleFundraiserStatus = async (event: SubstrateEvent, status: StoStatus): Promise<void> => {
   const { params, extrinsic, block, blockId } = extractArgs(event);
   const [, rawStoId] = params;
-  const offeringAssetId = getAssetId(extrinsic.extrinsic.args[0], block);
+  const offeringAssetId = await getAssetId(extrinsic.extrinsic.args[0], block);
   const stoId = getNumberValue(rawStoId);
 
   const sto = await Sto.get(`${offeringAssetId}/${stoId}`);
@@ -66,7 +66,7 @@ const handleFundraiserStatus = async (event: SubstrateEvent, status: StoStatus):
 export const handleFundraiserWindowModified = async (event: SubstrateEvent): Promise<void> => {
   const { params, extrinsic, blockId, block } = extractArgs(event);
   const [, rawStoId, , , rawStart, rawEnd] = params;
-  const offeringAssetId = getAssetId(extrinsic.extrinsic.args[0], block);
+  const offeringAssetId = await getAssetId(extrinsic.extrinsic.args[0], block);
   const stoId = getNumberValue(rawStoId);
 
   const sto = await Sto.get(`${offeringAssetId}/${stoId}`);

--- a/src/utils/portfolios.ts
+++ b/src/utils/portfolios.ts
@@ -36,13 +36,13 @@ export const getPortfolioId = ({
   number,
 }: Pick<Portfolio, 'identityId' | 'number'>): string => `${identityId}/${number}`;
 
-export const getCaIdValue = (
+export const getCaIdValue = async (
   item: Codec,
   block: SubstrateBlock
-): Pick<Distribution, 'localId' | 'assetId'> => {
+): Promise<Pick<Distribution, 'localId' | 'assetId'>> => {
   const caId = JSON.parse(item.toString());
   return {
     localId: extractNumber(caId, 'local_id'),
-    assetId: getAssetId(caId.ticker ?? caId.assetId, block),
+    assetId: await getAssetId(caId.ticker ?? caId.assetId, block),
   };
 };

--- a/src/utils/stos.ts
+++ b/src/utils/stos.ts
@@ -40,7 +40,7 @@ export const getFundraiserDetails = async (
     end: getDateValue(end),
     tiers,
     minimumInvestment: extractBigInt(rest, 'minimum_investment'),
-    offeringAssetId: getAssetId(extractString(rest, 'offering_asset'), block),
+    offeringAssetId: await getAssetId(extractString(rest, 'offering_asset'), block),
     offeringPortfolioId: getPortfolioId(offeringPortfolio),
     raisingAssetId,
     raisingTicker,

--- a/src/utils/transferManagers.ts
+++ b/src/utils/transferManagers.ts
@@ -63,10 +63,10 @@ export const getTransferManagerValue = (
   throw new Error('Unknown transfer restriction type found');
 };
 
-export const getExemptKeyValue = (
+export const getExemptKeyValue = async (
   item: Codec,
   block: SubstrateBlock
-): Omit<Attributes<TransferComplianceExemption>, 'exemptedEntityId'> => {
+): Promise<Omit<Attributes<TransferComplianceExemption>, 'exemptedEntityId'>> => {
   const exemptKey = JSON.parse(item.toString());
 
   const { op, operationType, claimType: claimTypeValue } = exemptKey;
@@ -89,7 +89,7 @@ export const getExemptKeyValue = (
   }
 
   return {
-    assetId: getAssetId(assetId, block),
+    assetId: await getAssetId(assetId, block),
     opType,
     claimType,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4748,10 +4748,10 @@
     tar "^6.1.13"
     tslib "^1"
 
-"@polymeshassociation/polymesh-types@^5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-types/-/polymesh-types-5.9.0.tgz#26d16613959909198e5233db35e57e8cdf55e6c4"
-  integrity sha512-kSJJAeC0mGiZpKWoYLu3TouzX9mgamb/Sp9AAlLjV8qncvmCZjVG4Yb+6TT7GC/79qjoegFzrIBf7euo0/AMiw==
+"@polymeshassociation/polymesh-types@^5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@polymeshassociation/polymesh-types/-/polymesh-types-5.14.0.tgz#f503ba81a0b9623b358b6aeb0c387737dd49bb22"
+  integrity sha512-7J3XamLzNLtMlZ21o6o7HdD7ts3fCz6J8hwh3L4b7fqTi1QyJeqep6HnguDwW3NksSrJ4clrKrSnMtxv9OnwHQ==
 
 "@protobuf-ts/grpc-transport@^2.8.2":
   version "2.9.1"
@@ -15337,7 +15337,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15422,7 +15431,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15449,6 +15458,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -16761,7 +16777,7 @@ wordwrapjs@^4.0.0:
     reduce-flatten "^2.0.0"
     typical "^5.2.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16783,6 +16799,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### Description

- Portfolio movements incorrectly had ticker value populated against asset ID field for Non Fungible tokens. This fixes the issue. (DA-1327)
- Adds new events and extrinsics from latest 7.x chain (DA-1333)
- Add new handler for mapping event `TickerUnlinkedFromAsset` (DA-1333)
- Update logic of asset ID generation for legacy tickers (to generate valid UUID) (DA-1333)
- Bump `@polymeshassociation/polymesh-types` to `5.14.0` (DA-1331)

### Breaking Changes

NA

### JIRA Link

DA-1327, DA-1333, DA-1331

### Checklist

- [ ] Updated the Readme.md (if required) ?
