### PR TITLE
fix: 🐛 use v7 storage when removing stale proposals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymesh-subquery",
-  "version": "17.1.2",
+  "version": "17.1.3",
   "author": "Polymesh Association",
   "license": "Apache-2.0",
   "description": "A Polymesh Chain Indexer, providing a GraphQL interface",

--- a/src/mappings/entities/block/mapChainUpgrade.ts
+++ b/src/mappings/entities/block/mapChainUpgrade.ts
@@ -24,7 +24,7 @@ export default async (substrateEvent: SubstrateEvent): Promise<void> => {
 
     if (txVersion !== transactionVersion) {
       logger.info(`Major chain upgrade found with transaction version upgraded `);
-      await handleMultiSigProposalDeleted(substrateEvent.block.block.header.number.toString());
+      await handleMultiSigProposalDeleted(substrateEvent.block);
       transactionVersion = txVersion;
     } else {
       logger.info(`Transaction version was not changed for the chain upgrade`);

--- a/src/mappings/entities/multiSig/mapMultiSigProposal.ts
+++ b/src/mappings/entities/multiSig/mapMultiSigProposal.ts
@@ -1,5 +1,5 @@
 import { Codec } from '@polkadot/types/types';
-import { SubstrateEvent } from '@subql/types';
+import { SubstrateBlock, SubstrateEvent } from '@subql/types';
 import {
   CallIdEnum,
   ModuleIdEnum,
@@ -213,13 +213,18 @@ export const handleMultiSigVoteRejected = async (event: SubstrateEvent): Promise
 };
 
 // triggered on major chain upgrades only
-export const handleMultiSigProposalDeleted = async (blockId: string): Promise<void> => {
+export const handleMultiSigProposalDeleted = async (block: SubstrateBlock): Promise<void> => {
+  const blockId = block.block.header.number.toString();
+
   const activeProposals = await store.getByFields<MultiSigProposal>('MultiSigProposal', [
     ['status', '=', MultiSigProposalStatusEnum.Active],
   ]);
 
+  const is7 = is7xChain(block);
+  const query = is7 ? api.query.multiSig.proposalStates : api.query.multiSig.proposalDetail;
+
   const queryMultiParams = activeProposals.map(proposal => [
-    api.query.multiSig.proposalDetail,
+    query,
     [proposal.multisigId, proposal.proposalId],
   ]);
 


### PR DESCRIPTION
update proposal cleanup logic to use v7 storage

### Description

<!-- Describe your changes in detail -->

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
