### PR TITLE
fix: 🐛 Correct multisig proposal params for batch calls

### DIFF
--- a/db/migrations/1_fix_multi_sig_proposals_data.sql
+++ b/db/migrations/1_fix_multi_sig_proposals_data.sql
@@ -1,0 +1,48 @@
+-- convert all module names to lowercase
+UPDATE multi_sig_proposals
+SET params = jsonb_set(
+    params,
+    '{proposals}',
+    (
+        SELECT jsonb_agg(
+            jsonb_set(
+                proposal,
+                '{module}',
+                to_jsonb(lower(proposal->>'module'))
+            )
+        )
+        FROM jsonb_array_elements(params->'proposals') AS proposal
+    )
+)
+WHERE params->'proposals' IS NOT NULL;
+
+-- correct the data format of 'params' when proposal with batch_all or batch_atomic is made
+UPDATE multi_sig_proposals
+SET params = jsonb_set(
+    jsonb_set(params, '{isBatch}', 'true'),
+    '{proposals}',
+    (
+        SELECT jsonb_agg(
+            (
+                elem - 'method' - 'section' -- Remove old keys
+            ) || jsonb_build_object(
+                'args', elem->>'args', -- stringify args
+                'call', ltrim(
+                    lower(
+                        regexp_replace(
+                            elem->>'method',
+                            '([A-Z])',
+                            '_\1',
+                            'g'
+                        )
+                    ),
+                    '_'
+                ), -- Convert method to snake_case and set as 'call'
+                'module', elem->>'section' -- Map section to module
+            )
+        )
+        FROM jsonb_array_elements(params->'proposals') AS proposal,
+             jsonb_array_elements((proposal->>'args')::jsonb->'calls') AS elem
+    )
+)
+WHERE params->'proposals'->0->>'call' in ('batch_all', 'batch_atomic');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymesh-subquery",
-  "version": "18.0.1",
+  "version": "18.0.2",
   "author": "Polymesh Association",
   "license": "Apache-2.0",
   "description": "A Polymesh Chain Indexer, providing a GraphQL interface",

--- a/src/mappings/entities/multiSig/mapMultiSigProposal.ts
+++ b/src/mappings/entities/multiSig/mapMultiSigProposal.ts
@@ -12,7 +12,6 @@ import {
 } from '../../../types';
 import {
   camelToSnakeCase,
-  capitalizeFirstLetter,
   extractString,
   getBooleanValue,
   getFirstKeyFromJson,
@@ -42,7 +41,7 @@ export const handleMultiSigProposalAdded = async (event: SubstrateEvent): Promis
 
   const callToProposalParam = (call: any): SingleProposal => {
     return {
-      module: capitalizeFirstLetter(call.section) as ModuleIdEnum,
+      module: call.section.toLowerCase() as ModuleIdEnum,
       call: camelToSnakeCase(call.method) as CallIdEnum,
       args: JSON.stringify(call.args),
     };
@@ -71,7 +70,8 @@ export const handleMultiSigProposalAdded = async (event: SubstrateEvent): Promis
     // for extrinsic bridge.propose_bridge_tx
     proposalParams.bridge = [args.bridge_tx];
     proposalParams.isBridge = true;
-  } else if (args?.proposal?.method === 'batch') {
+  } else if (args?.proposal?.method?.startsWith('batch')) {
+    // for batch, batch_atomic, batch_all, batch_optimistic
     proposalParams.isBatch = true;
     proposalParams.proposals = args?.proposal?.args?.calls?.map(callToProposalParam);
     proposalParams.expiry = args.expiry;


### PR DESCRIPTION
### Description

While adding support for multisig proposals in SDK, it was found out that 'params' value in 'MultisigProposal' entity was not saving correct data in case when proposal was added with call including 'batch_atomic' or 'batch_all'. The batch check in place was only checking for 'batch' extrinsic from the 'utility' pallet. 

This PR adds in the support for the same and adds in data migration SQL to fix the existing data.

### Breaking Changes

NA

### JIRA Link

DA-1398

### Checklist

- [ ] Updated the Readme.md (if required) ?
