### PR TITLE
fix: 🐛 Update status as Failed for failed instructions

### DIFF
--- a/db/migrations/3_update_failed_instruction_status.sql
+++ b/db/migrations/3_update_failed_instruction_status.sql
@@ -1,0 +1,3 @@
+update instructions
+set status = 'Failed'
+where failure_reason is not null and status != 'Failed';

--- a/src/mappings/entities/settlements/mapSettlement.ts
+++ b/src/mappings/entities/settlements/mapSettlement.ts
@@ -543,6 +543,7 @@ export const handleFailedToExecuteInstruction = async (event: SubstrateEvent): P
   const failureReason = getErrorDetails(rawDispatchError);
 
   instruction.updatedBlockId = blockId;
+  instruction.status = InstructionStatusEnum.Failed;
   instruction.failureReason = failureReason;
 
   const finalizedEvent = InstructionEvent.create({


### PR DESCRIPTION
### Description

The value of `status` field was not getting updated when instruction was being updated with `failure_reason` (in the event `FailedToExecuteInstruction`)

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

DA-1407

### Checklist

- [ ] Updated the Readme.md (if required) ?
