### PR TITLE
fix: 🐛 Correct handler mapping for `TransactionFeePaid` event

### DIFF
--- a/project.ts
+++ b/project.ts
@@ -312,8 +312,7 @@ const filters = {
     NewAccount: [],
   },
   transactionPayment: {
-    TransactionFeePaid: [],
-    FeeCharged: ['handleTransactionFeeCharged'],
+    TransactionFeePaid: ['handleTransactionFeeCharged'],
   },
   treasury: {
     TreasuryDisbursement: ['handleTreasuryDisbursement'],


### PR DESCRIPTION
BREAKING CHANGE: 🧨 Since the entries for `TransactionFeePaid` event where not indexed, this will require a full re-sync

### Description

Correct handler mapping for `TransactionFeePaid` event. 

This got messed up in the commit - https://github.com/PolymeshAssociation/polymesh-subquery/pull/236/files#diff-45b7bc2074fd178435206ac01414cde32b1413b2e783a1c568a7ab6f4fbc14d0L362 where in refactoring the code to project.ts file and renaming of the method 

### Breaking Changes

Since the entries for `TransactionFeePaid` event where not indexed, this will require a full re-sync

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
