### PR TITLE
fix: 🐛 correct parsing for balance transfer event

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       start_period: 30s
 
   graphql-engine:
-    image: onfinality/subql-query:v2.8.0
+    image: onfinality/subql-query:v2.21.0
     ports:
       - 3001:3000
     depends_on:

--- a/src/mappings/entities/identities/mapPolyxTransaction.ts
+++ b/src/mappings/entities/identities/mapPolyxTransaction.ts
@@ -36,13 +36,12 @@ export const handleTreasuryReimbursement = async (event: SubstrateEvent): Promis
   const details = getEventParams(args);
 
   if (details.extrinsicId) {
-    const transactions = await getPaginatedData<PolyxTransaction, 'extrinsicId'>(
-      'PolyxTransaction',
-      'extrinsicId',
-      details.extrinsicId
-    );
+    const transactions: PolyxTransaction[] = await getPaginatedData<
+      PolyxTransaction,
+      'extrinsicId'
+    >('PolyxTransaction', 'extrinsicId', details.extrinsicId);
 
-    const protocolFeePolyxTransaction = transactions.find(
+    const protocolFeePolyxTransaction: PolyxTransaction | undefined = transactions.find(
       ({ eventId }) => eventId === EventIdEnum.FeeCharged
     );
 
@@ -94,13 +93,12 @@ export const handleTreasuryDisbursement = async (event: SubstrateEvent): Promise
   const details = getEventParams(args);
 
   if (details.extrinsicId) {
-    const transactions = await getPaginatedData<PolyxTransaction, 'extrinsicId'>(
-      'PolyxTransaction',
-      'extrinsicId',
-      details.extrinsicId
-    );
+    const transactions: PolyxTransaction[] = await getPaginatedData<
+      PolyxTransaction,
+      'extrinsicId'
+    >('PolyxTransaction', 'extrinsicId', details.extrinsicId);
 
-    const transferPolyxTransaction = transactions.find(
+    const transferPolyxTransaction: PolyxTransaction | undefined = transactions.find(
       ({ eventId }) => eventId === EventIdEnum.Transfer
     );
     /**
@@ -146,12 +144,12 @@ export const handleBalanceTransfer = async (event: SubstrateEvent): Promise<void
   const details = getEventParams(args);
 
   if (details.extrinsicId) {
-    const transactions = await getPaginatedData<PolyxTransaction, 'extrinsicId'>(
-      'PolyxTransaction',
-      'extrinsicId',
-      details.extrinsicId
-    );
-    const endowedPolyxTransaction = transactions.find(
+    const transactions: PolyxTransaction[] = await getPaginatedData<
+      PolyxTransaction,
+      'extrinsicId'
+    >('PolyxTransaction', 'extrinsicId', details.extrinsicId);
+
+    const endowedPolyxTransaction: PolyxTransaction | undefined = transactions.find(
       ({ eventId }) => eventId === EventIdEnum.Endowed
     );
     /**
@@ -192,12 +190,12 @@ export const handleTransactionFeeCharged = async (event: SubstrateEvent): Promis
 
   const details = getEventParams(args);
   if (details.extrinsicId) {
-    const transactions = await getPaginatedData<PolyxTransaction, 'extrinsicId'>(
-      'PolyxTransaction',
-      'extrinsicId',
-      details.extrinsicId
-    );
-    const reimbursementTransaction = transactions
+    const transactions: PolyxTransaction[] = await getPaginatedData<
+      PolyxTransaction,
+      'extrinsicId'
+    >('PolyxTransaction', 'extrinsicId', details.extrinsicId);
+
+    const reimbursementTransaction: PolyxTransaction | undefined = transactions
       .slice()
       .reverse()
       .find(({ eventId }) => eventId === EventIdEnum.TreasuryReimbursement);

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -3,7 +3,6 @@ import { Codec } from '@polkadot/types/types';
 import { BN, hexHasPrefix, hexStripPrefix, isHex, u8aToHex, u8aToString } from '@polkadot/util';
 import { SubstrateBlock, SubstrateExtrinsic } from '@subql/types';
 import { Entity } from '@subql/types-core';
-import { Attributes } from 'src/mappings/entities/common';
 import { ErrorJson, FoundType } from '../types';
 export const emptyDid = '0x00'.padEnd(66, '0');
 
@@ -282,7 +281,7 @@ export const is7xChain = (block: SubstrateBlock) => {
   return specVersion >= 7000000 || (specName === 'polymesh_private_dev' && specVersion >= 2000000);
 };
 
-export const getPaginatedData = async <T extends Omit<Entity, 'id'>, F extends keyof Attributes<T>>(
+export const getPaginatedData = async <T extends Entity, F extends keyof T>(
   entityName: string,
   field: F,
   param: T[F]
@@ -291,16 +290,19 @@ export const getPaginatedData = async <T extends Omit<Entity, 'id'>, F extends k
   const result: T[] = [];
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const data = await store.getByField<T & { id: string }>(entityName, field, param, {
+    const data = await store.getByField<T>(entityName, field, param, {
       limit: 100,
       offset,
       orderBy: field,
       orderDirection: 'ASC',
     });
+
     result.push(...data);
+
     if (data.length < 100) {
       break;
     }
+
     offset += data.length;
   }
   return result;


### PR DESCRIPTION
### Description

When SQ is run using the docker image, balance.transfer is getting failed with reason, `e.save is not a function` while handling balance transfer event. This is a possible solution to the problem. 

(P.S. This error is not occuring when directly creating the image using the code instead of using image from docker hub)

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
