### PR TITLE
fix: 🐛 handle chain 8.0.0 VenueSignersUpdated shape and index InstructionUnlocked

### DIFF
--- a/db/migrations/19_add_instruction_unlocked_event_type.sql
+++ b/db/migrations/19_add_instruction_unlocked_event_type.sql
@@ -1,0 +1,1 @@
+alter type "3e29b3f361" add value if not exists 'InstructionUnlocked' after 'InstructionLocked';

--- a/project.ts
+++ b/project.ts
@@ -253,6 +253,7 @@ const filters: Record<string, Record<string, string[]>> = {
     InstructionRejected: ['handleInstructionRejected'],
     InstructionRescheduled: [],
     InstructionUnauthorized: ['handleInstructionUpdate'],
+    InstructionUnlocked: ['handleInstructionFinalizedEvent'],
     LegFailedExecution: [],
     MediatorAffirmationReceived: ['handleMediatorAffirmationReceived'],
     MediatorAffirmationWithdrawn: ['handleMediatorAffirmationWithdrawn'],

--- a/schema.graphql
+++ b/schema.graphql
@@ -2383,6 +2383,7 @@ enum InstructionEventEnum {
   InstructionExecuted
   InstructionFailed
   InstructionLocked
+  InstructionUnlocked
   InstructionMediators
   AffirmationWithdrawn
   InstructionRejected

--- a/src/mappings/entities/settlements/mapSettlement.ts
+++ b/src/mappings/entities/settlements/mapSettlement.ts
@@ -40,6 +40,11 @@ const instructionStatusMap = {
   [EventIdEnum.InstructionCreated]: InstructionStatusEnum.Created,
   [EventIdEnum.FailedToExecuteInstruction]: InstructionStatusEnum.Failed,
   [EventIdEnum.InstructionLocked]: InstructionStatusEnum.Locked,
+  /**
+   * unlocking returns the instruction to `Pending`, which the schema represents with the same
+   * `Created` status used when the instruction was first created
+   */
+  [EventIdEnum.InstructionUnlocked]: InstructionStatusEnum.Created,
 };
 
 /**
@@ -532,6 +537,7 @@ export const handleInstructionRejected = async (event: SubstrateEvent): Promise<
  *   - settlement.InstructionExecuted
  *   - settlement.InstructionFailed
  *   - settlement.InstructionLocked
+ *   - settlement.InstructionUnlocked
  */
 export const handleInstructionFinalizedEvent = async (event: SubstrateEvent): Promise<void> => {
   const { params, extrinsic, eventId, eventIdx, blockId, blockEventId } = extractArgs(event);

--- a/src/mappings/entities/settlements/mapVenue.ts
+++ b/src/mappings/entities/settlements/mapVenue.ts
@@ -10,6 +10,16 @@ import {
 } from '../../../utils';
 import { extractArgs } from '../common';
 
+/**
+ * Extracts venue signer addresses from the raw `VenueSignersUpdated` event param.
+ *
+ * From chain 8.0.0, `signers` is emitted as a `BTreeSet<AccountId>` (a native `Set`, which has
+ * no `.map`) instead of the `Vec<AccountId>` used until 7.x (array-like, has `.map`).
+ * `Array.from` accepts both iterables uniformly.
+ */
+export const extractVenueSigners = (rawSigners: Iterable<Codec>): string[] =>
+  Array.from(rawSigners).map(signer => signer.toString());
+
 const getVenue = async (venueId: string): Promise<Venue> => {
   const venue = await Venue.get(venueId);
 
@@ -65,7 +75,7 @@ export const handleVenueSignersUpdated = async (event: SubstrateEvent): Promise<
   const { params, blockId } = extractArgs(event);
   const [, rawVenueId, rawSigners, rawUpdateType] = params;
 
-  const signers = (rawSigners as unknown as Codec[]).map(signer => signer.toString());
+  const signers = extractVenueSigners(rawSigners as unknown as Iterable<Codec>);
 
   const id = getTextValue(rawVenueId);
   const venue = await getVenue(id);

--- a/tests/unit/mapVenue.test.ts
+++ b/tests/unit/mapVenue.test.ts
@@ -1,0 +1,32 @@
+import '@subql/types-core/dist/global';
+import '@subql/types/dist/global';
+import { extractVenueSigners } from '../../src/mappings/entities/settlements/mapVenue';
+
+/**
+ * Regression tests for the `VenueSignersUpdated` chain 8.0.0 shape change: the `signers` param
+ * changed from a `Vec<AccountId>` (array-like, has `.map`) to a `BTreeSet<AccountId>` (a native
+ * `Set`, which has no `.map` and previously crashed the indexer with `o.map is not a function`).
+ */
+describe('extractVenueSigners', () => {
+  const mockSigner = (address: string) => ({ toString: () => address });
+
+  it('extracts addresses from an array-like Vec (pre-8.x chain)', () => {
+    const rawSigners = [mockSigner('addr1'), mockSigner('addr2')];
+
+    expect(extractVenueSigners(rawSigners as any)).toStrictEqual(['addr1', 'addr2']);
+  });
+
+  it('extracts addresses from a Set-like BTreeSet (8.x chain)', () => {
+    const rawSigners = new Set([mockSigner('addr1'), mockSigner('addr2')]);
+
+    expect(extractVenueSigners(rawSigners as any)).toStrictEqual(['addr1', 'addr2']);
+  });
+
+  it('returns an empty array for an empty Set', () => {
+    expect(extractVenueSigners(new Set() as any)).toStrictEqual([]);
+  });
+
+  it('returns an empty array for an empty Vec', () => {
+    expect(extractVenueSigners([] as any)).toStrictEqual([]);
+  });
+});


### PR DESCRIPTION
### Description

VenueSignersUpdated's `signers` field changed from `Vec<AccountId>` to `BTreeSet<AccountId>` on chain 8.0.0. BTreeSet extends the native Set, which has no `.map`, so handleVenueSignersUpdated threw `TypeError: o.map is not a function` on every such event and permanently stalled the indexer. Array.from handles both shapes uniformly.

settlement.InstructionUnlocked was never registered as a handled event, so the indexed Instruction status stayed LockedForExecution forever after an unlock, even though the on-chain status correctly reverted to Pending. Wires it up to the existing InstructionLocked/Executed/Failed handler (same event shape) and maps it to the Created status, which is what the SDK reads back as Pending. Adds the InstructionUnlocked value to InstructionEventEnum and its DB enum migration so it can be logged as an InstructionEvent.

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
