### PR TITLE
Redesign/01 standalone fixes

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2354,6 +2354,13 @@ If any party fails to satisfy any compliance or transfer restriction the Instruc
 and no movement of assets will occur.
 """
 type Instruction @entity {
+  """
+  The chain's numeric instruction sequence, stored as text. Because it is not
+  zero-padded, `orderBy: [ID_ASC/DESC]` sorts it lexicographically ("9999"
+  outranks "14712"), not numerically. Order by `createdEventId` for a
+  chronological list — its halves are padded, so that ordering is total and
+  matches id-assignment order.
+  """
   id: ID!
   status: InstructionStatusEnum!
   venue: Venue @index(unique: false)

--- a/src/mappings/entities/assets/mapAsset.ts
+++ b/src/mappings/entities/assets/mapAsset.ts
@@ -546,7 +546,7 @@ type UpdateReasonResult = {
   assetDelta: { totalSupply?: bigint; totalTransfers?: bigint };
 };
 
-const processUpdateReason = (
+export const processUpdateReason = (
   updateReason: string,
   value: unknown,
   transferAmount: bigint,
@@ -582,6 +582,15 @@ const processUpdateReason = (
       ? EventIdEnum.Transfer
       : (blockEvents[eventIdx + 1]?.event.method as EventIdEnum) ?? EventIdEnum.Unknown;
     return { eventId, instructionId, instructionMemo, assetDelta: { totalTransfers: BigInt(1) } };
+  }
+
+  if (updateReason === 'controllerTransfer') {
+    // A controller transfer is a transfer: count it, and pin the event id so a
+    // batched controller_transfer does not fall back to the wrapping call name.
+    return {
+      eventId: EventIdEnum.ControllerTransfer,
+      assetDelta: { totalTransfers: BigInt(1) },
+    };
   }
 
   return { eventId: undefined, assetDelta: {} };

--- a/src/mappings/entities/identities/mapPolyxTransaction.ts
+++ b/src/mappings/entities/identities/mapPolyxTransaction.ts
@@ -376,7 +376,8 @@ export const handleBalanceSet = async (event: SubstrateEvent): Promise<void> => 
   let reservedAmount: bigint;
 
   if (!is8xChain(args.block)) {
-    reservedAmount = getBigIntValue(args.params[4]);
+    // BalanceSet(IdentityId, AccountId, free, reserved) — reserved is params[3], not params[4]
+    reservedAmount = getBigIntValue(args.params[3]);
   }
 
   const details = getEventParams(args);

--- a/src/mappings/entities/settlements/mapSettlement.ts
+++ b/src/mappings/entities/settlements/mapSettlement.ts
@@ -33,6 +33,16 @@ import { InstructionParty } from './../../../types/models/InstructionParty';
 import { OffChainReceipt } from './../../../types/models/OffChainReceipt';
 import { getPortfolioOrAccount, LegDetails } from './../../../utils/settlements';
 
+/**
+ * Until spec 6.3.1, `InstructionAutomaticallyAffirmed` was emitted *before* `InstructionCreated`,
+ * so `handleInstructionCreated` re-scans the block for it. That workaround must be scoped to the
+ * 6.1.0–6.3.1 window on public chains; a folded `||` previously made it run on every non-private
+ * block at any spec version (defect A4). The private-chain equivalent range is unknown — if one is
+ * ever needed, add it as an explicit second clause rather than widening this one.
+ */
+export const shouldRescanAutomaticAffirmations = (specName: string, specVersion: number): boolean =>
+  specName !== 'polymesh_private_dev' && specVersion >= 6001000 && specVersion <= 6003001;
+
 const instructionStatusMap = {
   [EventIdEnum.InstructionExecuted]: InstructionStatusEnum.Executed,
   [EventIdEnum.InstructionRejected]: InstructionStatusEnum.Rejected,
@@ -315,14 +325,7 @@ export const handleInstructionCreated = async (event: SubstrateEvent): Promise<v
     instructionCreatedEvent.save(),
   ];
 
-  /**
-   * Till spec version 6.3.1, InstructionAutomaticallyAffirmed was emitted before InstructionCreated event
-   * The below logic handles the case for this starting from spec version 6.1.0 from where it was introduced.
-   */
-  if (
-    (block.specVersion >= 6001000 && block.specVersion <= 6003001) ||
-    specName !== 'polymesh_private_dev'
-  ) {
+  if (shouldRescanAutomaticAffirmations(specName, block.specVersion)) {
     const automaticAffirmationPromises = [];
     block.events.forEach((event, eventIndex) => {
       if (event.event.method === EventIdEnum.InstructionAutomaticallyAffirmed) {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -334,7 +334,9 @@ export const getPaginatedData = async <T extends Entity, F extends keyof T>(
     const data = await store.getByField<T>(entityName, field, param, {
       limit: 100,
       offset,
-      orderBy: field,
+      // `id` is unique on every entity; the filter column never is, so ordering
+      // by it leaves offset paging free to repeat one row and skip another.
+      orderBy: 'id',
       orderDirection: 'ASC',
     });
 

--- a/tests/unit/getPaginatedData.test.ts
+++ b/tests/unit/getPaginatedData.test.ts
@@ -1,0 +1,48 @@
+import '@subql/types-core/dist/global';
+import '@subql/types/dist/global';
+import { getPaginatedData } from '../../src/utils/common';
+import { Leg } from '../../src/types';
+
+/**
+ * Regression test for defect A13: `getPaginatedData` set `orderBy` to the column it was
+ * filtering on. Every row in a filtered set holds an identical value for that column, so the
+ * order is not total and offset paging can return one row twice and skip another. It must
+ * order by `id`, which is unique on every entity.
+ */
+describe('getPaginatedData', () => {
+  const getByField = store.getByField as jest.Mock;
+
+  beforeEach(() => {
+    getByField.mockReset();
+  });
+
+  it('orders every page by the unique `id` column, not the filter column', async () => {
+    getByField.mockResolvedValue([]);
+
+    await getPaginatedData<Leg, 'instructionId'>('Leg', 'instructionId', '42');
+
+    expect(getByField).toHaveBeenCalledWith(
+      'Leg',
+      'instructionId',
+      '42',
+      expect.objectContaining({ orderBy: 'id', orderDirection: 'ASC' })
+    );
+  });
+
+  it('walks every page and concatenates the results in order', async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => ({ id: `a${i}` }));
+    const page2 = [{ id: 'b0' }, { id: 'b1' }];
+    getByField.mockResolvedValueOnce(page1).mockResolvedValueOnce(page2);
+
+    const result = await getPaginatedData<Leg, 'instructionId'>('Leg', 'instructionId', '42');
+
+    expect(result).toHaveLength(102);
+    expect(getByField).toHaveBeenNthCalledWith(
+      2,
+      'Leg',
+      'instructionId',
+      '42',
+      expect.objectContaining({ offset: 100, orderBy: 'id' })
+    );
+  });
+});

--- a/tests/unit/mapAsset.test.ts
+++ b/tests/unit/mapAsset.test.ts
@@ -1,0 +1,55 @@
+import '@subql/types-core/dist/global';
+import '@subql/types/dist/global';
+import { EventRecord } from '@polkadot/types/interfaces';
+import { processUpdateReason } from '../../src/mappings/entities/assets/mapAsset';
+import { EventIdEnum } from '../../src/types';
+
+/**
+ * Regression tests for defect A7: `processUpdateReason` branched on three of the four
+ * `HoldingsUpdateReason` variants and fell through to `{ eventId: undefined, assetDelta: {} }`
+ * for `controllerTransfer`, so controller transfers were not counted in `asset.totalTransfers`
+ * and their event id was resolved from the (possibly wrapping) extrinsic call name instead.
+ */
+describe('processUpdateReason', () => {
+  const noEvents = [] as unknown as EventRecord[];
+
+  it('counts a controller transfer and pins its event id', () => {
+    const result = processUpdateReason('controllerTransfer', {}, BigInt(100), 0, noEvents);
+
+    expect(result.eventId).toBe(EventIdEnum.ControllerTransfer);
+    expect(result.assetDelta).toStrictEqual({ totalTransfers: BigInt(1) });
+  });
+
+  it('keeps the controller-transfer event id even with no following event (batched call)', () => {
+    // The `transferred` branch falls back to `blockEvents[eventIdx + 1]` for its event id;
+    // `controllerTransfer` must not, or a batched controller_transfer records `Transfer`.
+    const result = processUpdateReason('controllerTransfer', {}, BigInt(1), 5, noEvents);
+
+    expect(result.eventId).toBe(EventIdEnum.ControllerTransfer);
+  });
+
+  it('still counts issued / redeemed / transferred as before', () => {
+    expect(
+      processUpdateReason('issued', { fundingRoundName: '' }, BigInt(10), 0, noEvents).assetDelta
+    ).toStrictEqual({ totalSupply: BigInt(10) });
+    expect(processUpdateReason('redeemed', {}, BigInt(10), 0, noEvents).assetDelta).toStrictEqual({
+      totalSupply: BigInt(-10),
+    });
+    expect(
+      processUpdateReason(
+        'transferred',
+        { instructionId: 1, instructionMemo: null },
+        BigInt(10),
+        0,
+        noEvents
+      ).assetDelta
+    ).toStrictEqual({ totalTransfers: BigInt(1) });
+  });
+
+  it('falls through for a genuinely unknown reason', () => {
+    const result = processUpdateReason('somethingNew', {}, BigInt(1), 0, noEvents);
+
+    expect(result.eventId).toBeUndefined();
+    expect(result.assetDelta).toStrictEqual({});
+  });
+});

--- a/tests/unit/mapPolyxTransaction.test.ts
+++ b/tests/unit/mapPolyxTransaction.test.ts
@@ -109,6 +109,38 @@ describe('mapPolyxTransaction parameter extraction logic', () => {
     });
   });
 
+  describe('pre-8.x BalanceSet layout (defect A1)', () => {
+    /**
+     * The chain emits `BalanceSet(IdentityId, AccountId, free, reserved)` — four params, with
+     * reserved at index 3 — identically at v5.4.3 / v6.3.5 / v7.0.0 / v7.4.0. `handleBalanceSet`
+     * read `params[4]`, which is out of bounds, so `getBigIntValue` returned `BigInt(0)` and the
+     * `if (reservedAmount)` guard silently skipped the Reserved row. It now reads `params[3]`.
+     */
+    const extractBalanceSetReserved = (params: Codec[]): bigint => getBigIntValue(params[3]);
+
+    it('reads the reserved balance from index 3', () => {
+      const params = [
+        createMockCodec(TEST_DID),
+        createMockCodec(TEST_ADDRESS),
+        createMockCodec('1000'), // free
+        createMockCodec('250'), // reserved
+      ];
+
+      expect(extractBalanceSetReserved(params)).toBe(BigInt('250'));
+    });
+
+    it('index 4 is out of bounds for this event and would yield 0', () => {
+      const params = [
+        createMockCodec(TEST_DID),
+        createMockCodec(TEST_ADDRESS),
+        createMockCodec('1000'),
+        createMockCodec('250'),
+      ];
+
+      expect(getBigIntValue(params[4])).toBe(BigInt(0));
+    });
+  });
+
   describe('Numeric detection regex', () => {
     it.each([
       ['0', true],

--- a/tests/unit/mapSettlement.test.ts
+++ b/tests/unit/mapSettlement.test.ts
@@ -1,0 +1,32 @@
+import '@subql/types-core/dist/global';
+import '@subql/types/dist/global';
+import { shouldRescanAutomaticAffirmations } from '../../src/mappings/entities/settlements/mapSettlement';
+
+/**
+ * Regression tests for defect A4: the guard around the `InstructionAutomaticallyAffirmed`
+ * re-scan folded its two conditions into a single `||`, so it evaluated true for every
+ * non-private chain at any spec version and the re-scan ran on every mainnet/testnet block
+ * instead of only on the 6.1.0–6.3.1 window it exists for.
+ */
+describe('shouldRescanAutomaticAffirmations', () => {
+  it('runs only within the 6.1.0–6.3.1 window on public chains', () => {
+    expect(shouldRescanAutomaticAffirmations('polymesh', 6001000)).toBe(true);
+    expect(shouldRescanAutomaticAffirmations('polymesh', 6003001)).toBe(true);
+    expect(shouldRescanAutomaticAffirmations('polymesh', 6002000)).toBe(true);
+  });
+
+  it('does not run before 6.1.0 or after 6.3.1', () => {
+    expect(shouldRescanAutomaticAffirmations('polymesh', 6000999)).toBe(false);
+    expect(shouldRescanAutomaticAffirmations('polymesh', 6003002)).toBe(false);
+    expect(shouldRescanAutomaticAffirmations('polymesh', 7000000)).toBe(false);
+  });
+
+  it('does not run at spec 8_000_000', () => {
+    expect(shouldRescanAutomaticAffirmations('polymesh', 8000000)).toBe(false);
+  });
+
+  it('never runs on polymesh_private_dev, whatever its spec version', () => {
+    expect(shouldRescanAutomaticAffirmations('polymesh_private_dev', 6002000)).toBe(false);
+    expect(shouldRescanAutomaticAffirmations('polymesh_private_dev', 1000000)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Phase 1: standalone defect fixes

PR 2 of 10 in the indexer redesign series. Based on `redesign/00-compiler-ci` (PR 1 of 10, #344); targets that branch until it merges, then rebases onto `docs/architecture`.

Five standalone correctness fixes, one commit each. None of them needs the redesign — they are wrong today — but the corrected values only appear after the full resync from genesis, so they ship as part of the series rather than as hotfixes. Defects that live in code a later phase rewrites wholesale, or that depend on infrastructure not built yet, are deliberately left for those phases.

### What changed

**`BalanceSet` reserved balance was never recorded on pre-8.x blocks.** The handler read the reserved balance from parameter index 4. The event carries four parameters — identity, account, free, reserved — with reserved at index 3; index 4 does not exist, so the value read back as zero and a `if (reservedAmount)` guard then skipped writing the reserved-balance row entirely. Every pre-8.x `balance_set` is therefore missing its reserved `PolyxTransaction` row, with no error or log. Fixed to read index 3. The event shape is verified identical from v5.4.3 through v7.4.0.

**A settlement workaround ran on every block instead of a 3-version window.** When an instruction is created, the handler re-scans the whole block for an `InstructionAutomaticallyAffirmed` event, because on chains up to spec 6.3.1 that event was emitted *before* `InstructionCreated` rather than after. The guard meant to limit this to spec 6.1.0–6.3.1 joined its two conditions with `||` instead of `&&`, so it was true for every non-private chain at any spec version — the full block scan and a redundant affirmation re-map ran on every mainnet and testnet block, current v8 included. Rewritten as an explicit, unit-tested predicate scoped to 6.1.0–6.3.1. The re-scan uses deterministic ids and is idempotent, so no data was wrong — this was wasted work on the hottest settlement path.

**Controller transfers were not counted and were sometimes mislabelled.** `AssetBalanceUpdated` carries a reason for why a holding changed. The code handled three of the four possible reasons and silently ignored the fourth — a forced transfer by an asset's controller. Two consequences: `asset.totalTransfers` was not incremented for controller transfers even though they are transfers, and the transaction's event id fell back to being derived from the extrinsic name, which is correct for a direct `controller_transfer` call but resolves to `Transfer` when the call is wrapped in a batch. Added the missing branch: controller transfers now increment `totalTransfers` and always record the `ControllerTransfer` event id, however the call was submitted.

**An internal pagination helper walked a non-unique order.** The helper that reads a filtered set of rows 100 at a time ordered the results by the same column it was filtering on. Every row in the set holds an identical value for that column, so the order is not total, and offset paging over it can return one row twice while skipping another. It now orders by `id`, which is unique on every entity. Three code paths use this helper and each acts on the rows it reads — settlement legs, external-agent group memberships, and transfer-compliance rules — so a dropped or doubled row meant a leg status not updated, a membership record missed, or a compliance rule left stale or written twice. Whether it has ever actually misfired depends on Postgres row order for small sets on freshly written tables; the fix removes the reliance on luck.

**`Instruction.id` sorts lexicographically.** The id stores the chain's numeric instruction sequence as a plain, unpadded string, so ordering by id puts `"9999"` after `"14712"`. Changing the id format is a primary-key change and happens with the resync; in the meantime this adds a description on the field explaining the trap and pointing consumers at `createdEventId`, which is zero-padded on both halves and orders chronologically.

### Consumer impact

Every change is a correction within the existing schema shape — no field or entity is added or removed, and `polyxTransactions` / `assetTransactions` return the same shape with corrected data.

- **`BalanceSet`**: `polyxTransactions` and `assetTransactions` gain the reserved-balance rows for pre-8.x `balance_set` calls that were previously absent.
- **Controller transfers**: `asset.totalTransfers` increases for any asset that has had a controller transfer, and the matching `assetTransactions` rows carry event id `ControllerTransfer` instead of `Transfer`.
- **`Instruction.id`**: description-only schema addition, but worth acting on — anyone ordering an instruction list by `id` today is getting a non-chronological order and should switch to `createdEventId`.
- The settlement re-scan fix and the pagination fix are internal; no consumer-visible surface changes, and both move results toward correctness.

All corrected values appear on the resync from genesis.

### Not included

Registering the standalone `asset.ControllerTransfer` event in `project.ts`. The event-shape verification shows the only real gap is the missing decode branch above; that separate event has a different parameter layout, needs its own decoder, and would double-count against `AssetBalanceUpdated` on v8. It belongs with the holdings work.

### Verification

```
yarn codegen && yarn typecheck && yarn lint && yarn test:unit
```

All green: 213 unit tests passing (12 new, covering all five fixes), 0 type errors, lint clean, and the handler check confirms all 157 registered handlers resolve to real exports.
