### PR TITLE
fix: silent multi-issuer Claim collisions and align Claim-domain schema [redesign(02)]

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2658,20 +2658,6 @@ type Scope @jsonField {
 }
 
 """
-The scope of a claim.
-
-e.g. `target` is Blocked from owning "TICKER-A" or `target` is an Affiliate of "TICKER-B"
-"""
-type ClaimScope @entity {
-  id: ID!
-  target: String! @index(unique: false)
-  asset: Asset
-  scope: Scope
-  createdBlock: Block!
-  updatedBlock: Block!
-}
-
-"""
 A claim made about an Identity. All active identities must have a valid CDD claim, but additional claims can be made.
 
 e.g. The Identity belongs to an accredited, US citizen

--- a/schema.graphql
+++ b/schema.graphql
@@ -2690,7 +2690,7 @@ Assets relying on on chain compliance should be explicit on which issuers they t
 type TrustedClaimIssuer @entity {
   id: ID!
   asset: Asset! @index(unique: false)
-  issuer: String! @index(unique: false)
+  issuer: Identity! @index(unique: false)
   eventIdx: Int!
   createdBlock: Block!
   updatedBlock: Block!

--- a/src/mappings/entities/assets/mapCompliance.ts
+++ b/src/mappings/entities/assets/mapCompliance.ts
@@ -130,7 +130,7 @@ export const handleTrustedDefaultClaimIssuerAdded = async (
     id: `${assetId}/${issuer}`,
     eventIdx,
     assetId,
-    issuer,
+    issuerId: issuer,
     createdBlockId: blockId,
     updatedBlockId: blockId,
     createdEventId: blockEventId,

--- a/src/mappings/entities/identities/mapClaim.ts
+++ b/src/mappings/entities/identities/mapClaim.ts
@@ -1,17 +1,9 @@
 import { GenericEvent } from '@polkadot/types/generic';
 import { SubstrateBlock, SubstrateEvent } from '@subql/types';
-import {
-  Claim,
-  ClaimScope,
-  ClaimScopeTypeEnum,
-  ClaimTypeEnum,
-  EventIdEnum,
-  Scope,
-} from '../../../types';
+import { Claim, ClaimScopeTypeEnum, ClaimTypeEnum, EventIdEnum, Scope } from '../../../types';
 import {
   END_OF_TIME,
   extractClaimInfo,
-  getAssetId,
   getAssetIdWithTicker,
   getTextValue,
   logError,
@@ -155,17 +147,6 @@ export const handleClaimAdded = async (event: SubstrateEvent): Promise<void> => 
     customClaimTypeId,
     createdEventId: blockEventId,
   }).save();
-
-  if (scope) {
-    await handleScopes(
-      blockId,
-      target,
-      scope.type === ClaimScopeTypeEnum.Asset || scope.type === ClaimScopeTypeEnum.Ticker
-        ? scope.value
-        : undefined,
-      scope
-    );
-  }
 };
 
 export const handleClaimRevoked = async (event: SubstrateEvent): Promise<void> => {
@@ -206,28 +187,13 @@ export const handleClaimRevoked = async (event: SubstrateEvent): Promise<void> =
   }
 };
 
-export const handleDidRegistered = async (event: SubstrateEvent): Promise<void> => {
-  const { params, blockId, block } = extractArgs(event);
-
-  const target = getTextValue(params[0]);
-  const assetId = await getAssetId(params[1], block);
-
-  await handleScopes(blockId, target, assetId);
-};
-
-const handleScopes = async (
-  blockId: string,
-  target: string,
-  assetId?: string,
-  scope?: Scope
-): Promise<void> => {
-  const id = `${target}/${scope?.value || assetId}`;
-  await ClaimScope.create({
-    id,
-    target,
-    assetId,
-    scope,
-    createdBlockId: blockId,
-    updatedBlockId: blockId,
-  }).save();
-};
+/**
+ * `AssetDidRegistered` previously only fed a `ClaimScope` row (the legacy ticker DID mapped
+ * to its asset). `ClaimScope` is removed — `Claim.scope` is already populated straight from
+ * `Asset` via `processClaimScope`/`getAssetIdWithTicker`, so nothing depended on that table.
+ * There is no other Claim-side state derived from this event, so this is now a no-op. The
+ * subscription in project.ts is left in place unchanged, per the redesign's `project.ts: No
+ * change` note for this phase.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const handleDidRegistered = async (event: SubstrateEvent): Promise<void> => {};

--- a/src/mappings/entities/identities/mapClaim.ts
+++ b/src/mappings/entities/identities/mapClaim.ts
@@ -14,6 +14,7 @@ import {
   getAssetId,
   getAssetIdWithTicker,
   getTextValue,
+  logError,
   logFoundType,
 } from '../../../utils';
 import { serializeLikeHarvester } from '../../serializeLikeHarvester';
@@ -40,15 +41,26 @@ const extractHarvesterArgs = (event: SubstrateEvent) => {
   });
 };
 
-const getId = (
+/**
+ * Claim id: `(target, issuer, claimType, …)` — current-state semantics, one row per
+ * issuer per claim. `issuer` is deliberately part of the id: without it, two trusted
+ * issuers attesting the same target/type/scope collide on the same row, and the SDK's
+ * `issuerId: { in: $trustedClaimIssuers }` filter silently loses whichever claim was
+ * written first (defect A12). Block/eventIdx are deliberately NOT part of the id — the
+ * SDK's claims query is a current-state question ("does T hold a valid claim from A?"),
+ * and an append-only id would force every consumer to add a "latest per group" filter
+ * they do not have today.
+ */
+export const getId = (
   target: string,
+  issuer: string,
   claimType: string,
   scope: Scope,
   jurisdiction: string,
   cddId: string,
   customClaimTypeId: string | undefined
 ): string => {
-  const idAttributes = [target, claimType];
+  const idAttributes = [target, issuer, claimType];
 
   if (customClaimTypeId) {
     idAttributes.push(customClaimTypeId);
@@ -123,7 +135,7 @@ export const handleClaimAdded = async (event: SubstrateEvent): Promise<void> => 
   );
 
   await Claim.create({
-    id: getId(target, claimType, scope, jurisdiction, cddId, customClaimTypeId),
+    id: getId(target, claimIssuer, claimType, scope, jurisdiction, cddId, customClaimTypeId),
     eventIdx,
     targetId: target,
     issuerId: claimIssuer,
@@ -135,6 +147,9 @@ export const handleClaimAdded = async (event: SubstrateEvent): Promise<void> => 
     jurisdiction,
     cddId,
     filterExpiry,
+    // A fresh `Claim.create` fully replaces any row at this id, so a re-issue after
+    // revocation implicitly clears `revokeDate` — stated here rather than left implicit.
+    revokeDate: undefined,
     createdBlockId: blockId,
     updatedBlockId: blockId,
     customClaimTypeId,
@@ -156,8 +171,15 @@ export const handleClaimAdded = async (event: SubstrateEvent): Promise<void> => 
 export const handleClaimRevoked = async (event: SubstrateEvent): Promise<void> => {
   const { params, block } = extractArgs(event);
   const harvesterArgs = extractHarvesterArgs(event);
-  const { claimScope, claimType, issuanceDate, cddId, jurisdiction, customClaimTypeId } =
-    extractClaimInfo(harvesterArgs);
+  const {
+    claimIssuer,
+    claimScope,
+    claimType,
+    issuanceDate,
+    cddId,
+    jurisdiction,
+    customClaimTypeId,
+  } = extractClaimInfo(harvesterArgs);
 
   let scope: Scope;
   if (claimScope) {
@@ -166,13 +188,21 @@ export const handleClaimRevoked = async (event: SubstrateEvent): Promise<void> =
 
   const target = getTextValue(params[0]);
 
-  const id = getId(target, claimType, scope, jurisdiction, cddId, customClaimTypeId);
+  const id = getId(target, claimIssuer, claimType, scope, jurisdiction, cddId, customClaimTypeId);
 
   const claim = await Claim.get(id);
 
   if (claim) {
     claim.revokeDate = issuanceDate;
     await claim.save();
+  } else {
+    // With issuer-scoped ids the lookup above is exact, so a miss here means the revoked
+    // claim was never indexed (or was indexed under a different id) rather than merely
+    // being one of several rows sharing an id, as it silently was before A12 was fixed.
+    // TODO(Phase 3): replace this with an `IndexerAnomaly` entity write once it lands.
+    logError(
+      `ClaimRevoked: no Claim found for id "${id}" (target: ${target}, issuer: ${claimIssuer}, type: ${claimType})`
+    );
   }
 };
 

--- a/tests/unit/mapClaim.test.ts
+++ b/tests/unit/mapClaim.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression tests for defect A12: `Claim`'s id omitted `issuer`, so two trusted issuers
+ * attesting the same target/type/scope collided on one row. Depending on write order this
+ * either silently lost one issuer's claim (`handleClaimAdded` overwrite) or silently revoked
+ * it (`handleClaimRevoked` mutating the shared row) — both invisible to the SDK's
+ * `issuerId: { in: $trustedClaimIssuers }` / `revokeDate: { isNull: true }` filters.
+ *
+ * `serializeLikeHarvester` is mocked to the identity function so event params can be passed
+ * as plain decoded objects instead of real polkadot `Codec`s — this file is only concerned
+ * with the id/store logic in mapClaim.ts, not with harvester-style serialization.
+ */
+
+import { SubstrateEvent } from '@subql/types';
+
+jest.mock('../../src/mappings/serializeLikeHarvester', () => ({
+  serializeLikeHarvester: (item: unknown) => item,
+}));
+
+import {
+  getId,
+  handleClaimAdded,
+  handleClaimRevoked,
+} from '../../src/mappings/entities/identities/mapClaim';
+
+const TARGET = TEST_DID;
+const ISSUER_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const ISSUER_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+const storeGet = (): jest.Mock => (globalThis as any).store.get as jest.Mock;
+const storeSet = (): jest.Mock => (globalThis as any).store.set as jest.Mock;
+
+/** A minimal Codec-like stand-in — only `.toString()` is exercised by the code under test. */
+const mockCodec = (value: string) => ({ toString: () => value });
+
+/**
+ * Builds a mock `ClaimAdded`/`ClaimRevoked` `SubstrateEvent` for a CustomerDueDiligence claim.
+ * CDD claims carry no `scope`, which keeps this out of `processClaimScope`
+ * (and its `getAssetIdWithTicker` chain) entirely — the id/store logic under test here
+ * does not depend on scope handling.
+ */
+const mockClaimEvent = (
+  method: 'ClaimAdded' | 'ClaimRevoked',
+  { issuer, cddId, dateValue }: { issuer: string; cddId: string; dateValue: string }
+): SubstrateEvent => {
+  const data = [
+    mockCodec(TARGET),
+    {
+      claim: { CustomerDueDiligence: cddId },
+      claim_issuer: issuer,
+      issuance_date: dateValue,
+      last_update_date: dateValue,
+    },
+  ];
+
+  return {
+    idx: 3,
+    block: {
+      block: { header: { number: { toString: () => '1234' } } },
+      timestamp: new Date('2026-01-01T00:00:00Z'),
+      specVersion: 8000000,
+    },
+    event: {
+      method,
+      section: 'identity',
+      data,
+      meta: {
+        fields: data.map(() => ({ typeName: { isSome: true, unwrap: () => mockCodec('Dummy') } })),
+      },
+    },
+  } as unknown as SubstrateEvent;
+};
+
+describe('getId', () => {
+  it('includes the issuer, producing distinct ids for two issuers over an otherwise identical claim', () => {
+    const idA = getId(
+      TARGET,
+      ISSUER_A,
+      'CustomerDueDiligence',
+      undefined,
+      undefined,
+      'cdd-1',
+      undefined
+    );
+    const idB = getId(
+      TARGET,
+      ISSUER_B,
+      'CustomerDueDiligence',
+      undefined,
+      undefined,
+      'cdd-1',
+      undefined
+    );
+
+    expect(idA).not.toBe(idB);
+    expect(idA).toBe(`${TARGET}/${ISSUER_A}/CustomerDueDiligence/cdd-1`);
+    expect(idB).toBe(`${TARGET}/${ISSUER_B}/CustomerDueDiligence/cdd-1`);
+  });
+
+  it('produces the same id for the same target/issuer/type/scope', () => {
+    const first = getId(
+      TARGET,
+      ISSUER_A,
+      'CustomerDueDiligence',
+      undefined,
+      undefined,
+      'cdd-1',
+      undefined
+    );
+    const second = getId(
+      TARGET,
+      ISSUER_A,
+      'CustomerDueDiligence',
+      undefined,
+      undefined,
+      'cdd-1',
+      undefined
+    );
+
+    expect(first).toBe(second);
+  });
+});
+
+describe('handleClaimAdded / handleClaimRevoked', () => {
+  let claims: Record<string, any>;
+
+  beforeEach(() => {
+    claims = {};
+
+    storeGet().mockImplementation((entity: string, id: string) => {
+      if (entity === 'Claim') {
+        return Promise.resolve(claims[id] ? { ...claims[id] } : undefined);
+      }
+      if (entity === 'Identity') {
+        // Short-circuit createIdentityIfNotExists — identity creation is not under test here.
+        return Promise.resolve({ id });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    storeSet().mockImplementation((entity: string, id: string, data: any) => {
+      if (entity === 'Claim') {
+        claims[id] = { ...data };
+      }
+      return Promise.resolve();
+    });
+  });
+
+  it('gives two issuers attesting the same target/type/scope two distinct Claim rows', async () => {
+    await handleClaimAdded(
+      mockClaimEvent('ClaimAdded', { issuer: ISSUER_A, cddId: 'cdd-1', dateValue: '1000' })
+    );
+    await handleClaimAdded(
+      mockClaimEvent('ClaimAdded', { issuer: ISSUER_B, cddId: 'cdd-1', dateValue: '2000' })
+    );
+
+    const ids = Object.keys(claims);
+    expect(ids).toHaveLength(2);
+
+    const idA = getId(
+      TARGET,
+      ISSUER_A,
+      'CustomerDueDiligence',
+      undefined,
+      undefined,
+      'cdd-1',
+      undefined
+    );
+    const idB = getId(
+      TARGET,
+      ISSUER_B,
+      'CustomerDueDiligence',
+      undefined,
+      undefined,
+      'cdd-1',
+      undefined
+    );
+
+    expect(claims[idA]).toMatchObject({ issuerId: ISSUER_A, targetId: TARGET });
+    expect(claims[idB]).toMatchObject({ issuerId: ISSUER_B, targetId: TARGET });
+  });
+
+  it('leaves issuer A untouched and unrevoked when issuer B revokes its own claim', async () => {
+    await handleClaimAdded(
+      mockClaimEvent('ClaimAdded', { issuer: ISSUER_A, cddId: 'cdd-1', dateValue: '1000' })
+    );
+    await handleClaimAdded(
+      mockClaimEvent('ClaimAdded', { issuer: ISSUER_B, cddId: 'cdd-1', dateValue: '2000' })
+    );
+
+    await handleClaimRevoked(
+      mockClaimEvent('ClaimRevoked', { issuer: ISSUER_B, cddId: 'cdd-1', dateValue: '3000' })
+    );
+
+    const idA = getId(
+      TARGET,
+      ISSUER_A,
+      'CustomerDueDiligence',
+      undefined,
+      undefined,
+      'cdd-1',
+      undefined
+    );
+    const idB = getId(
+      TARGET,
+      ISSUER_B,
+      'CustomerDueDiligence',
+      undefined,
+      undefined,
+      'cdd-1',
+      undefined
+    );
+
+    expect(claims[idA].revokeDate).toBeUndefined();
+    expect(claims[idB].revokeDate).toBe('3000');
+  });
+
+  it('clears revokeDate when the same issuer re-issues the claim after revoking it', async () => {
+    await handleClaimAdded(
+      mockClaimEvent('ClaimAdded', { issuer: ISSUER_A, cddId: 'cdd-1', dateValue: '1000' })
+    );
+
+    await handleClaimRevoked(
+      mockClaimEvent('ClaimRevoked', { issuer: ISSUER_A, cddId: 'cdd-1', dateValue: '2000' })
+    );
+
+    const id = getId(
+      TARGET,
+      ISSUER_A,
+      'CustomerDueDiligence',
+      undefined,
+      undefined,
+      'cdd-1',
+      undefined
+    );
+    expect(claims[id].revokeDate).toBe('2000');
+
+    await handleClaimAdded(
+      mockClaimEvent('ClaimAdded', { issuer: ISSUER_A, cddId: 'cdd-1', dateValue: '3000' })
+    );
+
+    expect(claims[id].revokeDate).toBeUndefined();
+  });
+
+  it('logs an error instead of silently returning when a revocation matches no row', async () => {
+    await handleClaimRevoked(
+      mockClaimEvent('ClaimRevoked', { issuer: ISSUER_A, cddId: 'cdd-1', dateValue: '1000' })
+    );
+
+    expect((globalThis as any).logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(ISSUER_A)
+    );
+    expect(Object.keys(claims)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Phase 2 — Claims

PR 3 of 10 in the indexer redesign series. Based on `redesign/01-standalone-fixes` (PR #345).

This is the only defect found in the whole review that silently returns wrong answers to a compliance code path. Everything else in the redesign is a missing capability or a recoverable error.

### What's in this PR

1. **`feat!: 🎸 include the issuer in the Claim id`** (defect A12) — `Claim`'s id omitted `issuer`, so two trusted issuers attesting the same target/type/scope collided on one row. Depending on write order, `handleClaimAdded` silently lost one issuer's claim, or `handleClaimRevoked` silently revoked it out from under the surviving issuer. `issuer` is now the second id component: `(target, issuer, claimType, …)`, current-state semantics, one row per issuer per claim. A revocation that finds no row now logs an error (a `TODO` marks it for replacement by an `IndexerAnomaly` write in Phase 3) instead of silently returning.
2. **`feat!: 🎸 remove the ClaimScope entity`** — duplicated `Claim.scope`, unqueried by either consumer.
3. **`feat!: 🎸 make TrustedClaimIssuer.issuer a relation`** — brings it in line with `Claim.issuer`. Escalated from the planned `refactor` to a breaking `feat!` after `yarn codegen` showed the generated filter field moves from `issuer` to `issuerId` (see commit body for detail).

### Consumer impact

**SDK impact.** `claimsQuery`, `claimsGroupingQuery`, `didsWithClaims` and `issuerDidsWithClaimsByTarget` change *behaviour*, not *shape* — no query needs to change. They will start returning claims that were previously silently lost to the issuer collision. **Claim counts will go up after the resync — that is the fix landing, not a regression.**

`TrustedClaimIssuer.issuer` moves from a plain string filter to `issuerId` (relation FK) plus a nested `issuer { ... }` object. No consumer currently filters `trustedClaimIssuers` by issuer per the consumer-query survey, but flagging the shape change explicitly since it wasn't in the original plan.

`ClaimScope` removal: unobserved by both consumers (SDK and portal), confirmed against `polymesh-sdk` origin/develop and `polymesh-portal` origin/main.

### Verification

```
yarn codegen && yarn typecheck && yarn lint && yarn test:unit
```

All green. New unit tests in `tests/unit/mapClaim.test.ts` cover:
- Two issuers attesting the same target/type/scope produce two distinct `Claim` rows (regression test for A12).
- A revocation by issuer B leaves issuer A's row untouched and unrevoked.
- Re-issue after revocation clears `revokeDate`.
- A revocation with no matching row logs an error instead of silently returning.

No `db/migrations/*` entries — decision D5, full resync from genesis.

