### PR TITLE
fix: 🐛 resolve RewardDestination from its camel-cased toJSON key

### DIFF
--- a/src/mappings/entities/events/mapStakingEvent.ts
+++ b/src/mappings/entities/events/mapStakingEvent.ts
@@ -4,7 +4,11 @@ import { SubstrateBlock, SubstrateEvent } from '@subql/types';
 import { Account, EventIdEnum, StakingEvent } from '../../../types';
 import { getBigIntValue, getTextValue } from '../../../utils';
 import { is8xChain } from '../../../utils/common';
-import { resolveLegacyRewardDestination } from '../../../utils/staking';
+import {
+  readRewardDestination,
+  resolveLegacyRewardDestination,
+  RewardDestinationName,
+} from '../../../utils/staking';
 import { extractArgs } from '../common';
 
 const bondedUnbondedOrReward = new Set([
@@ -14,50 +18,25 @@ const bondedUnbondedOrReward = new Set([
   EventIdEnum.Rewarded, // from 7.x Reward was renamed to Rewarded
 ]);
 
-type RewardDestinationDetails = {
-  type: string;
-  account?: string;
-};
-
 type StakingEventDetails = {
   amount?: bigint;
   stashAccount?: string;
   nominatedValidators?: string[];
   identityId?: string;
-  rewardDestination?: string;
+  rewardDestination?: RewardDestinationName;
   rewardDestinationAccount?: string;
 };
 
-const getRewardDestinationDetails = (destParam: Codec): RewardDestinationDetails => {
-  const json = destParam.toJSON() as string | Record<string, unknown>;
-
-  if (typeof json === 'string') {
-    return { type: json };
-  }
-
-  const variant = Object.keys(json)[0] ?? 'Unknown';
-
-  const value = json[variant];
-
-  if (variant === 'Account') {
-    return {
-      type: variant,
-      account: typeof value === 'string' ? value : undefined,
-    };
-  }
-
-  return { type: variant };
-};
-
 const getRewardDestinationAccount = (
-  destinationDetails: RewardDestinationDetails,
+  destination: RewardDestinationName,
+  account?: string,
   stashAccount?: string
 ): string | undefined => {
-  if (destinationDetails.type === 'Account') {
-    return destinationDetails.account;
+  if (destination === 'Account') {
+    return account;
   }
 
-  if (destinationDetails.type === 'Staked' || destinationDetails.type === 'Stash') {
+  if (destination === 'Staked' || destination === 'Stash') {
     return stashAccount;
   }
 
@@ -88,13 +67,13 @@ const get8xStakingEventDetails = (eventId: EventIdEnum, params: Codec[]): Stakin
   const stashAccount = getTextValue(rawAccount);
 
   if (eventId === EventIdEnum.Rewarded) {
-    const destinationDetails = getRewardDestinationDetails(rawSecondParam);
+    const { destination, account } = readRewardDestination(rawSecondParam.toJSON());
 
     return {
       stashAccount,
       amount: getBigIntValue(rawThirdParam),
-      rewardDestination: destinationDetails.type,
-      rewardDestinationAccount: getRewardDestinationAccount(destinationDetails, stashAccount),
+      rewardDestination: destination,
+      rewardDestinationAccount: getRewardDestinationAccount(destination, account, stashAccount),
     };
   }
 

--- a/src/utils/staking.ts
+++ b/src/utils/staking.ts
@@ -1,9 +1,73 @@
+import type { AnyJson } from '@polkadot/types/types';
+
+/**
+ * The chain's own `RewardDestination` variants, plus the placeholder recorded when the payee
+ * cannot be read at all.
+ *
+ * Spelled out rather than derived from `PalletStakingRewardDestination['type']`: `src/index.ts`
+ * loads both `polymesh-types` and `@polkadot/types-augment`, and each declares that interface
+ * into `@polkadot/types/lookup`. The duplicate declaration collapses `type` to a bare `string`
+ * (the conflict is in `node_modules`, so `skipLibCheck` hides it) — `is*`/`as*` survive it,
+ * `type` does not — so deriving the union would silently widen it back to `string`.
+ */
+export type RewardDestinationName =
+  | 'Staked'
+  | 'Stash'
+  | 'Controller'
+  | 'Account'
+  | 'None'
+  | 'LegacyUnknown';
+
 export interface LegacyRewardDestination {
-  /** `Staked` | `Stash` | `Controller` | `Account` | `None` | `LegacyUnknown` (read failed) */
-  rewardDestination: string;
+  rewardDestination: RewardDestinationName;
   /** The account the reward was actually paid to, where it can be resolved */
   rewardDestinationAccount?: string;
 }
+
+/** `.toJSON()` camel-cases the variant name; this maps it back to the name the index records. */
+const rewardDestinationByVariant: Record<string, RewardDestinationName> = {
+  staked: 'Staked',
+  stash: 'Stash',
+  controller: 'Controller',
+  account: 'Account',
+  none: 'None',
+};
+
+/**
+ * Reads a decoded `RewardDestination` — from storage or from an event parameter — out of its
+ * `.toJSON()` form.
+ *
+ * `.toJSON()` rather than the generated `Option<PalletStakingRewardDestination>` accessors,
+ * deliberately: the generated types describe one metadata snapshot — the current one — while
+ * both callers read blocks from runtimes that predate it, and `api` decodes against the block's
+ * own registry. `.unwrap()` written against today's `OptionQuery` throws on a block where the
+ * entry decodes as a bare `RewardDestination`, and that throw lands in a `catch` that would turn
+ * every reward into `LegacyUnknown`. `.toJSON()` is the one accessor whose output is the same
+ * either way: `null`, a bare string (`"Staked"` — when every variant of that runtime's type is a
+ * unit variant), or a single-key object with the variant camel-cased (`{ staked: null }`,
+ * `{ account: "0x…" }`).
+ *
+ * An unrecognised variant resolves to `None` — no destination account is claimed for it.
+ */
+export const readRewardDestination = (
+  json: AnyJson
+): { destination: RewardDestinationName; account?: string } => {
+  let variant = '';
+  let value: AnyJson = null;
+
+  if (typeof json === 'string') {
+    variant = json;
+  } else if (json && typeof json === 'object' && !Array.isArray(json)) {
+    [variant = ''] = Object.keys(json);
+    value = json[variant] ?? null;
+  }
+
+  const destination = rewardDestinationByVariant[variant.toLowerCase()] ?? 'None';
+
+  return destination === 'Account' && typeof value === 'string'
+    ? { destination, account: value }
+    : { destination };
+};
 
 /**
  * Per-stash cache of a resolved payee. `staking.payee(stash)` is a chain-storage read on every
@@ -39,34 +103,26 @@ export const resolveLegacyRewardDestination = async (
 
   try {
     const payee = await api.query.staking.payee(stash);
-    const json = payee.toJSON() as string | Record<string, unknown> | null;
-
-    // `RewardDestination` renders either as a bare string (`"Staked"`) or, via `.toJSON()`, as a
-    // single-key object with the variant name lower-cased (`{ staked: null }`, `{ account: "0x…" }`).
-    const variant = (
-      typeof json === 'string' ? json : Object.keys(json ?? {})[0] ?? ''
-    ).toLowerCase();
-    const value =
-      json && typeof json === 'object' ? (json as Record<string, unknown>)[variant] : undefined;
+    const { destination, account } = readRewardDestination(payee.toJSON());
 
     let result: LegacyRewardDestination;
 
-    if (variant === 'staked' || variant === 'stash') {
+    if (destination === 'Staked' || destination === 'Stash') {
       result = {
-        rewardDestination: variant === 'staked' ? 'Staked' : 'Stash',
+        rewardDestination: destination,
         rewardDestinationAccount: stash,
       };
-    } else if (variant === 'controller') {
-      const controller = (await api.query.staking.bonded(stash)).toJSON() as string | null;
+    } else if (destination === 'Controller') {
+      const controller = (await api.query.staking.bonded(stash)).toJSON();
 
       result = {
         rewardDestination: 'Controller',
-        rewardDestinationAccount: controller ?? undefined,
+        rewardDestinationAccount: typeof controller === 'string' ? controller : undefined,
       };
-    } else if (variant === 'account') {
+    } else if (destination === 'Account') {
       result = {
         rewardDestination: 'Account',
-        rewardDestinationAccount: typeof value === 'string' ? value : undefined,
+        rewardDestinationAccount: account,
       };
     } else {
       result = { rewardDestination: 'None' };

--- a/tests/unit/rewardDestinationA15.test.ts
+++ b/tests/unit/rewardDestinationA15.test.ts
@@ -134,7 +134,7 @@ describe('A15 — pre-v8 reward destination', () => {
     await handleStakingEvent(
       rewardEvent(
         'Rewarded',
-        [codec(STASH), { toJSON: () => ({ Account: PAYEE }) }, codec('3000')],
+        [codec(STASH), { toJSON: () => ({ account: PAYEE }) }, codec('3000')],
         8_000_000
       )
     );
@@ -147,6 +147,20 @@ describe('A15 — pre-v8 reward destination', () => {
   it('v8 resolves Staked/Stash to the stash itself', async () => {
     await handleStakingEvent(
       rewardEvent('Rewarded', [codec(STASH), { toJSON: () => 'Staked' }, codec('4000')], 8_000_000)
+    );
+
+    const row = savedStakingEvent();
+    expect(row.rewardDestination).toBe('Staked');
+    expect(row.rewardDestinationAccount).toBe(STASH);
+  });
+
+  it('v8 resolves the object form of a Staked payee to the stash', async () => {
+    await handleStakingEvent(
+      rewardEvent(
+        'Rewarded',
+        [codec(STASH), { toJSON: () => ({ staked: null }) }, codec('4500')],
+        8_000_000
+      )
     );
 
     const row = savedStakingEvent();


### PR DESCRIPTION
Found while reviewing #349.

`Enum#toJSON()` camel-cases the variant name (`stringCamelCase(this.type)` in `@polkadot/types-codec`), but `getRewardDestinationDetails` compared the key against `'Account'`. So an 8.x `Rewarded` with an explicit `Account` payee arrived as `{ account: "5..." }`, the branch never fired, and the row was stored as `rewardDestination: 'account'` with `rewardDestinationAccount` undefined. Every object form was affected — `{ staked: null }` stored `'staked'` and resolved no account either.

The parse now lives once in `utils/staking.ts`, shared with the pre-v8 `staking.payee` read that had it right. Along the way:

- takes `AnyJson` and narrows, instead of casting `toJSON()` to `string | Record<string, unknown> | null`
- `rewardDestination` is a union of the variant names, not `string`
- `.toJSON()` stays in place of the generated `Option<PalletStakingRewardDestination>` accessors, and the reason is recorded at the helper: the generated types describe the current metadata only, while both callers read older runtimes, so `.unwrap()` would throw into a `catch` on a block where the entry decodes as a bare `RewardDestination`

Tests cover `{ account }`, `{ staked: null }` and the bare-string form on the 8.x path; the object-form cases fail without the fix.
