### PR TITLE
fix: 🐛 post-resync defects found testing redesign/07 against real chain data

### DIFF
--- a/src/decode/field.ts
+++ b/src/decode/field.ts
@@ -7,15 +7,30 @@ import { FieldNotFound } from './errors';
 export type DecodedEvent = Readonly<Record<string, Codec>>;
 
 /**
+ * `asset_id` -> `assetId`. A no-op for a name with no underscore, so an already-camelCase name
+ * (the common case so far) passes through unchanged rather than being lowercased.
+ */
+const toCamelCase = (name: string): string =>
+  name.includes('_')
+    ? name.replace(/_([a-zA-Z0-9])/g, (_match, c: string) => c.toUpperCase())
+    : name;
+
+/**
  * The field names the block's own metadata gives this event, in parameter order.
  *
  * Since metadata v14 the metadata is self-describing: a struct-style event carries a name per
  * field and a tuple-style one carries none. `mapEvent` already straddles this boundary for
  * `typeName`; this reads the sibling `name`.
+ *
+ * Substrate's own macros name fields idiomatic-Rust snake_case (`asset_id`), while every shape
+ * table and handler in this codebase reads camelCase (`assetId`) - the convention `#[derive]`d
+ * upstream-pallet events (and, on a later runtime, some of Polymesh's own) already happen to
+ * satisfy only when the name has no underscore to begin with. Normalising here, once, is what
+ * lets the shape table and every handler stay camelCase-only.
  */
 export const metadataFieldNames = (event: SubstrateEvent): (string | undefined)[] =>
   (event.event as unknown as GenericEvent).meta.fields.map(({ name }) =>
-    name.isSome ? name.unwrap().toString() : undefined
+    name.isSome ? toCamelCase(name.unwrap().toString()) : undefined
   );
 
 /**

--- a/src/mappings/entities/assets/mapAsset.ts
+++ b/src/mappings/entities/assets/mapAsset.ts
@@ -539,7 +539,7 @@ export const handleAssetTransfer = async (event: SubstrateEvent): Promise<void> 
   let toDid: string;
 
   if (!rawFromHolder.isEmpty) {
-    fromHolder = await rawAssetHolderToAssetHolder(rawFromHolder, block, blockId);
+    fromHolder = await rawAssetHolderToAssetHolder(rawFromHolder, block, blockId, blockEventId);
     fromDid = fromHolder.identityId;
     if (fromDid === emptyDid) {
       return; // We ignore the transfer case when Asset tokens are issued
@@ -549,7 +549,7 @@ export const handleAssetTransfer = async (event: SubstrateEvent): Promise<void> 
   let toHolder: AssetHolderDetails | undefined;
 
   if (!rawToHolder.isEmpty) {
-    toHolder = await rawAssetHolderToAssetHolder(rawToHolder, block, blockId);
+    toHolder = await rawAssetHolderToAssetHolder(rawToHolder, block, blockId, blockEventId);
     toDid = toHolder.identityId;
     if (toDid === emptyDid) {
       toDid = null;
@@ -700,13 +700,13 @@ export const handleAssetBalanceUpdated = async (event: SubstrateEvent): Promise<
   let fromHolder: AssetHolderDetails | undefined;
 
   if (!rawFromHolder.isEmpty) {
-    fromHolder = await rawAssetHolderToAssetHolder(rawFromHolder, block, blockId);
+    fromHolder = await rawAssetHolderToAssetHolder(rawFromHolder, block, blockId, blockEventId);
     await applyHoldingDelta(asset, fromHolder, blockEventId, -transferAmount, promises);
   }
   let toHolder: AssetHolderDetails | undefined;
 
   if (!rawToHolder.isEmpty) {
-    toHolder = await rawAssetHolderToAssetHolder(rawToHolder, block, blockId);
+    toHolder = await rawAssetHolderToAssetHolder(rawToHolder, block, blockId, blockEventId);
     await applyHoldingDelta(asset, toHolder, blockEventId, transferAmount, promises);
   }
 

--- a/src/mappings/entities/assets/mapAssetMetadata.ts
+++ b/src/mappings/entities/assets/mapAssetMetadata.ts
@@ -3,9 +3,11 @@ import { decodeEvent } from '../../../decode';
 import {
   AnomalyKind,
   AssetMetadata,
+  CallIdEnum,
   CustomAssetType,
   GlobalMetadataKey,
   MetadataScope,
+  MultiSigProposal,
 } from '../../../types';
 import {
   bytesToString,
@@ -22,13 +24,55 @@ type MetadataKey = { scope: MetadataScope; keyId: string };
 /** `{ Local: n } | { Global: n }`, from an event param or an extrinsic arg. The `n` is a `u64`. */
 const parseMetadataKey = (raw: unknown): MetadataKey | undefined => {
   const obj = (typeof raw === 'string' ? JSON.parse(raw) : raw) as Record<string, number | string>;
+  // `toHuman()` formats a `u64` with thousands separators ("1,234"); `toJSON()` and `getTextValue`
+  // do not. Strip them so the same key id round-trips to the same `AssetMetadata` row regardless
+  // of which path below resolved it.
+  const keyId = (id: number | string): string => `${id}`.replace(/,/g, '');
   if (obj && ('local' in obj || 'Local' in obj)) {
-    return { scope: MetadataScope.Local, keyId: `${obj.local ?? obj.Local}` };
+    return { scope: MetadataScope.Local, keyId: keyId(obj.local ?? obj.Local) };
   }
   if (obj && ('global' in obj || 'Global' in obj)) {
-    return { scope: MetadataScope.Global, keyId: `${obj.global ?? obj.Global}` };
+    return { scope: MetadataScope.Global, keyId: keyId(obj.global ?? obj.Global) };
   }
   return undefined;
+};
+
+/** The fields of a block `EventRecord` this module reads — avoids the CJS/ESM `EventRecord` clash. */
+type BlockEventRecord = {
+  event: { section: string; method: string };
+  phase: { isApplyExtrinsic: boolean; asApplyExtrinsic: { toNumber: () => number } };
+};
+
+const isFromExtrinsic = (record: BlockEventRecord, extrinsicIdx: number | undefined): boolean =>
+  extrinsicIdx !== undefined &&
+  record.phase.isApplyExtrinsic &&
+  record.phase.asApplyExtrinsic.toNumber() === extrinsicIdx;
+
+/**
+ * `event`'s 0-based position among `SetAssetMetadataValue` / `...ValueDetails` siblings dispatched
+ * by the same extrinsic. A batch or multisig proposal runs its calls in order and each
+ * `setAssetMetadata(Details)` call fires exactly one such event, so this ordinal lines up with
+ * that call's own position among the batch's/proposal's `setAssetMetadata(Details)` entries —
+ * needed because more than one can target the *same* asset (set now, tighten the lock later),
+ * where matching by `asset_id` alone cannot tell them apart.
+ */
+const metadataSiblingOrdinal = (event: SubstrateEvent): number => {
+  const events = event.block.events as unknown as BlockEventRecord[];
+  const extrinsicIdx = event.extrinsic?.idx;
+
+  let ordinal = 0;
+  for (let i = 0; i < event.idx; i += 1) {
+    const record = events[i];
+    if (
+      record?.event.section === 'asset' &&
+      (record.event.method === 'SetAssetMetadataValue' ||
+        record.event.method === 'SetAssetMetadataValueDetails') &&
+      isFromExtrinsic(record, extrinsicIdx)
+    ) {
+      ordinal += 1;
+    }
+  }
+  return ordinal;
 };
 
 /**
@@ -36,11 +80,15 @@ const parseMetadataKey = (raw: unknown): MetadataKey | undefined => {
  * either the call args or a sibling event, in that order:
  *
  * 1. a direct `asset.setAssetMetadata` / `setAssetMetadataDetails` call — the key is `args[1]`;
- * 2. `asset.registerAndSetLocalAssetMetadata`, which registers the key and sets its value in one
+ * 2. the same call, batched alongside others in one `utility.batch*` extrinsic (e.g. `createAsset`
+ *    + `setAssetMetadata` for a new asset's initial metadata) — see `metadataKeyFromBatch`;
+ * 3. the same call, executed via `multiSig.approve` of a previously-created proposal — see
+ *    `metadataKeyFromMultiSigProposal`;
+ * 4. `asset.registerAndSetLocalAssetMetadata`, which registers the key and sets its value in one
  *    call and so emits `RegisterAssetMetadataLocalType` in the same extrinsic, just before this
  *    event — that carries the new key id.
  *
- * Only when neither resolves (an unrecognised wrapper) is the row dropped with an anomaly.
+ * Only when none resolves (an unrecognised wrapper) is the row dropped with an anomaly.
  */
 const metadataKeyFromExtrinsic = (
   extrinsic: SubstrateExtrinsic | undefined
@@ -55,16 +103,102 @@ const metadataKeyFromExtrinsic = (
   return parseMetadataKey(extrinsic.extrinsic.args[1]?.toJSON());
 };
 
-/** The fields of a block `EventRecord` this module reads — avoids the CJS/ESM `EventRecord` clash. */
-type BlockEventRecord = {
-  event: { section: string; method: string };
-  phase: { isApplyExtrinsic: boolean; asApplyExtrinsic: { toNumber: () => number } };
+/** One call as `Extrinsic.toHuman().method` shapes it — named, snake_case args. */
+type HumanCall = { section: string; method: string; args: Record<string, unknown> };
+
+const isSetMetadataCall = (call: HumanCall): boolean =>
+  call.section === 'asset' &&
+  (call.method === 'setAssetMetadata' || call.method === 'setAssetMetadataDetails');
+
+/** Every `utility` call that dispatches a `Vec<Call>` in order, including the legacy/forced forms. */
+const BATCH_METHODS = [
+  'batch',
+  'batchAll',
+  'batchAtomic',
+  'batchOptimistic',
+  'forceBatch',
+  'batchOld',
+];
+
+/**
+ * `asset.setAssetMetadata(Details)` batched alongside other calls in one `utility.batch*`
+ * extrinsic. The outer, signed extrinsic is `utility.*`, not `asset.*`, so `metadataKeyFromExtrinsic`
+ * never matches it — and there is commonly no sibling registration event either, since this usually
+ * sets a pre-existing global key rather than registering a new local one. The matching call is
+ * picked by ordinal among the batch's own `setAssetMetadata(Details)` entries (`metadataSiblingOrdinal`)
+ * and then checked against `assetId` as a consistency guard, so a mismatch (an unexpected call
+ * order) falls through to the anomaly rather than writing the wrong asset's key.
+ *
+ * Pre-7.0 history is out of reach here: `asset_id` never matches a batched call's legacy `ticker`
+ * arg, so those fall straight through to the anomaly, same as today.
+ */
+const metadataKeyFromBatch = (event: SubstrateEvent, assetId: string): MetadataKey | undefined => {
+  const extrinsic = event.extrinsic;
+  if (!extrinsic) {
+    return undefined;
+  }
+
+  const method = extrinsic.extrinsic.method;
+  if (method.section !== 'utility' || !BATCH_METHODS.includes(method.method)) {
+    return undefined;
+  }
+
+  const human = extrinsic.extrinsic.toHuman() as { method?: { args?: { calls?: HumanCall[] } } };
+  const call = (human.method?.args?.calls ?? []).filter(isSetMetadataCall)[
+    metadataSiblingOrdinal(event)
+  ];
+
+  return call?.args.asset_id === assetId ? parseMetadataKey(call.args.key) : undefined;
 };
 
-const isFromExtrinsic = (record: BlockEventRecord, extrinsicIdx: number | undefined): boolean =>
-  extrinsicIdx !== undefined &&
-  record.phase.isApplyExtrinsic &&
-  record.phase.asApplyExtrinsic.toNumber() === extrinsicIdx;
+/**
+ * The same call, executed via `multiSig.approve` of a proposal created earlier. The call never
+ * appears on the `approve` extrinsic itself, and `multiSig.proposals` storage is cleared once a
+ * proposal executes — but the indexer already captured it at `ProposalAdded` time:
+ * `MultiSigProposal.params.proposals` holds the module/call/args of the proposed call (flattened
+ * one level if the proposal was itself a batch — a batch-of-batches proposal is not unwrapped
+ * further and falls through to the anomaly), keyed `${multisig}/${proposalId}`, exactly what
+ * `approve`'s own args carry. Matched the same way as `metadataKeyFromBatch`: by ordinal, then
+ * checked against `assetId`.
+ */
+const metadataKeyFromMultiSigProposal = async (
+  event: SubstrateEvent,
+  assetId: string
+): Promise<MetadataKey | undefined> => {
+  const extrinsic = event.extrinsic;
+  if (!extrinsic) {
+    return undefined;
+  }
+
+  const method = extrinsic.extrinsic.method;
+  if (method.section !== 'multiSig' || method.method !== 'approve') {
+    return undefined;
+  }
+
+  const [rawMultiSig, rawProposalId] = extrinsic.extrinsic.args;
+  if (!rawMultiSig || !rawProposalId) {
+    return undefined;
+  }
+
+  // `.toString()` directly, not `getTextValue`/`getNumberValue` — `extrinsic.extrinsic.args`
+  // resolves through the `@polkadot/types-codec` cjs build, a distinct (if structurally
+  // identical) `Codec` from the esm one those helpers are typed against.
+  const proposal = await MultiSigProposal.get(
+    `${rawMultiSig.toString()}/${Number(rawProposalId.toString())}`
+  );
+
+  const call = (proposal?.params.proposals ?? []).filter(
+    p =>
+      p.call === CallIdEnum.set_asset_metadata || p.call === CallIdEnum.set_asset_metadata_details
+  )[metadataSiblingOrdinal(event)];
+
+  if (!call) {
+    return undefined;
+  }
+
+  const args = JSON.parse(call.args) as Record<string, unknown>;
+  return args.asset_id === assetId ? parseMetadataKey(args.key) : undefined;
+};
 
 /**
  * The key id from a `RegisterAssetMetadata{Local,Global}Type` emitted earlier in the same
@@ -96,8 +230,14 @@ const metadataKeyFromSiblingRegistration = (event: SubstrateEvent): MetadataKey 
     : { scope: MetadataScope.Global, keyId: getTextValue(decoded.globalKeyId) };
 };
 
-const resolveMetadataKey = (event: SubstrateEvent): MetadataKey | undefined =>
-  metadataKeyFromExtrinsic(event.extrinsic) ?? metadataKeyFromSiblingRegistration(event);
+const resolveMetadataKey = async (
+  event: SubstrateEvent,
+  assetId: string
+): Promise<MetadataKey | undefined> =>
+  metadataKeyFromExtrinsic(event.extrinsic) ??
+  metadataKeyFromBatch(event, assetId) ??
+  (await metadataKeyFromMultiSigProposal(event, assetId)) ??
+  metadataKeyFromSiblingRegistration(event);
 
 const metadataId = (assetId: string, key: MetadataKey): string =>
   `${assetId}/${key.scope}/${key.keyId}`;
@@ -201,12 +341,12 @@ export const handleSetAssetMetadataValue = async (event: SubstrateEvent): Promis
   const { assetId: rawAssetId, value: rawValue, detail: rawDetail } = decodeEvent(event);
 
   const assetId = await getAssetId(rawAssetId, block);
-  const key = resolveMetadataKey(event);
+  const key = await resolveMetadataKey(event, assetId);
 
   if (!key) {
     await recordAnomaly({
       kind: AnomalyKind.MissingReferencedEntity,
-      detail: `SetAssetMetadataValue for asset ${assetId} could not resolve its metadata key from the extrinsic or a sibling registration event`,
+      detail: `SetAssetMetadataValue for asset ${assetId} could not resolve its metadata key from the extrinsic, a batch, a multisig proposal, or a sibling registration event`,
       block,
       eventIdx: event.idx,
     });
@@ -227,7 +367,7 @@ export const handleSetAssetMetadataValueDetails = async (event: SubstrateEvent):
   const { assetId: rawAssetId, detail: rawDetail } = decodeEvent(event);
 
   const assetId = await getAssetId(rawAssetId, block);
-  const key = resolveMetadataKey(event);
+  const key = await resolveMetadataKey(event, assetId);
   if (!key) {
     return;
   }

--- a/src/mappings/entities/assets/mapAssetMetadata.ts
+++ b/src/mappings/entities/assets/mapAssetMetadata.ts
@@ -111,14 +111,14 @@ const isSetMetadataCall = (call: HumanCall): boolean =>
   (call.method === 'setAssetMetadata' || call.method === 'setAssetMetadataDetails');
 
 /** Every `utility` call that dispatches a `Vec<Call>` in order, including the legacy/forced forms. */
-const BATCH_METHODS = [
+const BATCH_METHODS = new Set([
   'batch',
   'batchAll',
   'batchAtomic',
   'batchOptimistic',
   'forceBatch',
   'batchOld',
-];
+]);
 
 /**
  * `asset.setAssetMetadata(Details)` batched alongside other calls in one `utility.batch*`
@@ -139,7 +139,7 @@ const metadataKeyFromBatch = (event: SubstrateEvent, assetId: string): MetadataK
   }
 
   const method = extrinsic.extrinsic.method;
-  if (method.section !== 'utility' || !BATCH_METHODS.includes(method.method)) {
+  if (method.section !== 'utility' || !BATCH_METHODS.has(method.method)) {
     return undefined;
   }
 

--- a/src/mappings/entities/assets/mapNfts.ts
+++ b/src/mappings/entities/assets/mapNfts.ts
@@ -175,13 +175,13 @@ export const handleNftHoldingsUpdates = async (event: SubstrateEvent): Promise<v
   let toDid: string;
 
   if (!rawFromHolder.isEmpty) {
-    fromHolder = await rawAssetHolderToAssetHolder(rawFromHolder, block, blockId);
+    fromHolder = await rawAssetHolderToAssetHolder(rawFromHolder, block, blockId, blockEventId);
     fromDid = fromHolder.identityId;
   }
   let toHolder: AssetHolderDetails | undefined;
 
   if (!rawToHolder.isEmpty) {
-    toHolder = await rawAssetHolderToAssetHolder(rawToHolder, block, blockId);
+    toHolder = await rawAssetHolderToAssetHolder(rawToHolder, block, blockId, blockEventId);
     toDid = toHolder.identityId;
   }
 

--- a/src/mappings/entities/settlements/mapSettlement.ts
+++ b/src/mappings/entities/settlements/mapSettlement.ts
@@ -207,7 +207,12 @@ const mapAutomaticAffirmation = async (
 ): Promise<[InstructionEvent, InstructionAffirmation]> => {
   const [, rawHolder, rawInstructionId] = params;
   const instructionId = processInstructionId(rawInstructionId);
-  const { identity, account, portfolio } = await getPortfolioOrAccount(rawHolder, block, blockId);
+  const { identity, account, portfolio } = await getPortfolioOrAccount(
+    rawHolder,
+    block,
+    blockId,
+    blockEventId
+  );
 
   const automaticAffirmationEvent = InstructionEvent.create({
     id: blockEventId,
@@ -283,7 +288,7 @@ export const handleInstructionCreated = async (event: SubstrateEvent): Promise<v
    * count did not change, so this is a payload branch rather than a positional one
    */
   if (specVersionOf(block) >= 6_000_000) {
-    legs = await getSettlementLeg(rawLegs, block, blockId);
+    legs = await getSettlementLeg(rawLegs, block, blockId, blockEventId);
   } else {
     legs = await getLegsValue(rawLegs, block);
   }
@@ -389,7 +394,8 @@ export const handleInstructionUpdate = async (event: SubstrateEvent): Promise<vo
   const { identity, account, portfolio } = await getPortfolioOrAccount(
     rawPortfolio,
     block,
-    blockId
+    blockId,
+    blockEventId
   );
 
   const partyId = getPartyId(instructionId, identity, account, false);
@@ -445,7 +451,8 @@ export const handleAffirmationWithdrawn = async (event: SubstrateEvent): Promise
   const { identity, account, portfolio } = await getPortfolioOrAccount(
     rawPortfolio,
     block,
-    blockId
+    blockId,
+    blockEventId
   );
 
   const partyId = getPartyId(instructionId, identity, account, false);
@@ -803,8 +810,8 @@ export const handleFundsTransferred = async (event: SubstrateEvent): Promise<voi
   const { fromHolder: rawFromHolder, toHolder: rawToHolder, fund: rawFund } = decodeEvent(event);
 
   const [fromHolder, toHolder] = await Promise.all([
-    rawAssetHolderToAssetHolder(rawFromHolder, block, blockId),
-    rawAssetHolderToAssetHolder(rawToHolder, block, blockId),
+    rawAssetHolderToAssetHolder(rawFromHolder, block, blockId, blockEventId),
+    rawAssetHolderToAssetHolder(rawToHolder, block, blockId, blockEventId),
   ]);
 
   const { description, memo } = JSON.parse(rawFund.toString());

--- a/src/utils/accounts.ts
+++ b/src/utils/accounts.ts
@@ -178,11 +178,11 @@ export const getOrCreateAccount = async (
   blockId: string,
   datetime: Date,
   /**
-   * The event this account is being created in response to. An account discovered lazily
-   * (through a chain read, or as a side effect of an unrelated handler) has no single causing
-   * event — callers that have the real one pass it; the rest fall back to the block's first
-   * event. D13's block-granularity caveat on `updatedEvent` applies. Threading the real id
-   * through the asset-holder resolution chain is a follow-up.
+   * The event this account is being created in response to. Every asset-holder-resolution call
+   * site (`meshAssetHolderToAssetHolder` and up) now threads its real `blockEventId` through; the
+   * fallback below covers the few callers that still don't have one to give — an account
+   * discovered by a genuinely event-less path (the genesis/seed scan) has no single causing event
+   * at all. D13's block-granularity caveat on `updatedEvent` applies either way.
    */
   createdEventId = `${blockId}/${padId('0')}`
 ): Promise<Account | undefined> => {

--- a/src/utils/portfolios.ts
+++ b/src/utils/portfolios.ts
@@ -112,10 +112,16 @@ export const rawPortfolioToAssetHolder = (item: Codec): AssetHolderDetails => {
 export const meshAssetHolderToAssetHolder = async (
   meshAssetHolder: MeshAssetHolder,
   blockId: string,
-  datetime: Date
+  datetime: Date,
+  blockEventId?: string
 ): Promise<AssetHolderDetails> => {
   if ('account' in meshAssetHolder) {
-    const account = await getOrCreateAccount(meshAssetHolder.account, blockId, datetime);
+    const account = await getOrCreateAccount(
+      meshAssetHolder.account,
+      blockId,
+      datetime,
+      blockEventId
+    );
     // `identityId` may be undefined here — an account with no known Identity is still a present
     // holder, and callers must classify on holder presence before DID equality.
     return accountHolder(account?.identityId, meshAssetHolder.account);
@@ -138,10 +144,16 @@ export const meshAssetHolderToAssetHolder = async (
 export const extractAssetHolder = async (
   value: MeshAssetHolder | MeshPortfolio,
   block: SubstrateBlock,
-  blockId: string
+  blockId: string,
+  blockEventId?: string
 ): Promise<AssetHolderDetails> => {
   if (is8xChain(block)) {
-    return await meshAssetHolderToAssetHolder(value as MeshAssetHolder, blockId, block.timestamp);
+    return await meshAssetHolderToAssetHolder(
+      value as MeshAssetHolder,
+      blockId,
+      block.timestamp,
+      blockEventId
+    );
   }
   return meshPortfolioToAssetHolder(value as MeshPortfolio);
 };
@@ -154,10 +166,11 @@ export const extractAssetHolder = async (
 export const rawAssetHolderToAssetHolder = async (
   rawItem: Codec,
   block: SubstrateBlock,
-  blockId: string
+  blockId: string,
+  blockEventId?: string
 ): Promise<AssetHolderDetails> => {
   const item = JSON.parse(rawItem.toString());
-  return extractAssetHolder(item, block, blockId);
+  return extractAssetHolder(item, block, blockId, blockEventId);
 };
 
 export const getPortfolioId = ({

--- a/src/utils/settlements.ts
+++ b/src/utils/settlements.ts
@@ -90,10 +90,11 @@ const processOnChainLeg = async (
   legType: LegTypeEnum,
   legIndex: number,
   block: SubstrateBlock,
-  blockId: string
+  blockId: string,
+  blockEventId?: string
 ): Promise<LegDetails> => {
-  const fromData = await extractAssetHolder(legValue.sender, block, blockId);
-  const toData = await extractAssetHolder(legValue.receiver, block, blockId);
+  const fromData = await extractAssetHolder(legValue.sender, block, blockId, blockEventId);
+  const toData = await extractAssetHolder(legValue.receiver, block, blockId, blockEventId);
 
   let from: string, to: string;
   let fromAccount: string | undefined, toAccount: string | undefined;
@@ -143,7 +144,8 @@ const processOnChainLeg = async (
 export const getSettlementLeg = async (
   item: Codec,
   block: SubstrateBlock,
-  blockId: string
+  blockId: string,
+  blockEventId?: string
 ): Promise<LegDetails[]> => {
   const legs: any[] = JSON.parse(item.toString());
 
@@ -160,7 +162,14 @@ export const getSettlementLeg = async (
       legDetails.push(processOffChainLeg(legValue, legIndex));
     } else {
       legDetails.push(
-        await processOnChainLeg(legValue, legType as LegTypeEnum, legIndex, block, blockId)
+        await processOnChainLeg(
+          legValue,
+          legType as LegTypeEnum,
+          legIndex,
+          block,
+          blockId,
+          blockEventId
+        )
       );
     }
 
@@ -204,10 +213,11 @@ export const getSettlementTypeDetails = (
 export const getPortfolioOrAccount = async (
   rawItem: Codec,
   block: SubstrateBlock,
-  blockId: string
+  blockId: string,
+  blockEventId?: string
 ): Promise<{ identity: string; account?: string; portfolio?: number }> => {
   const item = JSON.parse(rawItem.toString());
-  const data = await extractAssetHolder(item, block, blockId);
+  const data = await extractAssetHolder(item, block, blockId, blockEventId);
   let account: string | undefined;
   let portfolio: number | undefined;
   let identityId: string;

--- a/tests/unit/assetHolderProvenance.test.ts
+++ b/tests/unit/assetHolderProvenance.test.ts
@@ -1,0 +1,91 @@
+/**
+ * A17 follow-up: the asset-holder resolution chain (`rawAssetHolderToAssetHolder` ->
+ * `extractAssetHolder` -> `meshAssetHolderToAssetHolder`) now threads the real `blockEventId`
+ * through to `getOrCreateAccount`, rather than always taking its block-event-0 default. A caller
+ * with no event to give (none currently; kept as a fallback) still gets the old behaviour.
+ */
+
+import { Codec } from '@polkadot/types/types';
+import { SubstrateBlock } from '@subql/types';
+import { getOrCreateAccount } from '../../src/utils/accounts';
+import {
+  extractAssetHolder,
+  meshAssetHolderToAssetHolder,
+  rawAssetHolderToAssetHolder,
+} from '../../src/utils/portfolios';
+import { codec } from './helpers';
+
+jest.mock('../../src/utils/accounts', () => ({
+  getOrCreateAccount: jest.fn(),
+}));
+
+const ADDRESS = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+const BLOCK_EVENT_ID = '0000012345/0000000003';
+
+const block8x = (): SubstrateBlock =>
+  ({
+    specVersion: 8_000_000,
+    timestamp: new Date('2026-01-01T00:00:00Z'),
+  } as unknown as SubstrateBlock);
+
+beforeEach(() => {
+  (getOrCreateAccount as jest.Mock).mockResolvedValue({ identityId: '0xdid' });
+});
+
+describe('meshAssetHolderToAssetHolder', () => {
+  it('passes the real blockEventId through to getOrCreateAccount when given one', async () => {
+    await meshAssetHolderToAssetHolder(
+      { account: ADDRESS },
+      '0000012345',
+      new Date('2026-01-01T00:00:00Z'),
+      BLOCK_EVENT_ID
+    );
+
+    expect(getOrCreateAccount).toHaveBeenCalledWith(
+      ADDRESS,
+      '0000012345',
+      expect.any(Date),
+      BLOCK_EVENT_ID
+    );
+  });
+
+  it('passes undefined through when no blockEventId is given, so getOrCreateAccount falls back on its own default', async () => {
+    await meshAssetHolderToAssetHolder({ account: ADDRESS }, '0000012345', new Date());
+
+    expect(getOrCreateAccount).toHaveBeenCalledWith(
+      ADDRESS,
+      '0000012345',
+      expect.any(Date),
+      undefined
+    );
+  });
+});
+
+describe('extractAssetHolder / rawAssetHolderToAssetHolder', () => {
+  it('threads blockEventId all the way from the raw codec to getOrCreateAccount', async () => {
+    await rawAssetHolderToAssetHolder(
+      codec({ account: ADDRESS }) as unknown as Codec,
+      block8x(),
+      '0000012345',
+      BLOCK_EVENT_ID
+    );
+
+    expect(getOrCreateAccount).toHaveBeenCalledWith(
+      ADDRESS,
+      '0000012345',
+      expect.any(Date),
+      BLOCK_EVENT_ID
+    );
+  });
+
+  it('extractAssetHolder threads it too, one level up from rawAssetHolderToAssetHolder', async () => {
+    await extractAssetHolder({ account: ADDRESS }, block8x(), '0000012345', BLOCK_EVENT_ID);
+
+    expect(getOrCreateAccount).toHaveBeenCalledWith(
+      ADDRESS,
+      '0000012345',
+      expect.any(Date),
+      BLOCK_EVENT_ID
+    );
+  });
+});

--- a/tests/unit/decode.test.ts
+++ b/tests/unit/decode.test.ts
@@ -93,6 +93,19 @@ describe('field', () => {
     expect(() => field(event, 'reserved')).toThrow(FieldNotFound);
     expect(() => field(event, 'reserved')).toThrow(/has no field "reserved"/);
   });
+
+  it('resolves a metadata field name given in snake_case by its camelCase equivalent', () => {
+    // seen from a later v8 testnet spec: `asset.Approval` carries [owner, spender, asset_id,
+    // amount] named fields, not the [owner, spender, assetId, amount] every handler reads
+    const event = namedEvent('asset', 'Approval', {
+      owner: '5Owner',
+      spender: '5Spender',
+      asset_id: '0xabc',
+      amount: '100',
+    });
+
+    expect(field(event, 'assetId').toString()).toBe('0xabc');
+  });
 });
 
 describe('decodeEvent, named events', () => {

--- a/tests/unit/mapAssetAllowance.test.ts
+++ b/tests/unit/mapAssetAllowance.test.ts
@@ -4,6 +4,7 @@
  * `amountSpent`, so a missed or reordered event cannot accumulate drift.
  */
 
+import { SubstrateEvent } from '@subql/types';
 import { handleAllowanceSpent, handleApproval } from '../../src/mappings/entities/assets/mapAsset';
 import { codec, MockDb, mockStore, tupleEvent } from './helpers';
 
@@ -13,6 +14,37 @@ const SPENDER = '5Spender000000000000000000000000000000000000000000';
 
 const allowanceEvent = (method: 'Approval' | 'AllowanceSpent', values: string[]) =>
   tupleEvent({ section: 'asset', method, data: values.map(v => codec(v)), blockNumber: '800' });
+
+/**
+ * The same event as a struct-style one, the shape a later v8 testnet runtime turned out to emit:
+ * metadata names every field, in idiomatic-Rust snake_case (`asset_id`, not `assetId`) — the
+ * defect this test guards (block 25,557,789, `asset.Approval`: "has no field \"assetId\"; it
+ * carries [owner, spender, asset_id, amount]").
+ */
+const namedAllowanceEvent = (
+  method: 'Approval' | 'AllowanceSpent',
+  fields: Record<string, string>
+): SubstrateEvent =>
+  ({
+    idx: 2,
+    block: {
+      block: { header: { number: { toString: () => '800' } } },
+      specVersion: 8_000_000,
+      timestamp: new Date('2026-01-01T00:00:00Z'),
+      events: [],
+    },
+    event: {
+      section: 'asset',
+      method,
+      data: Object.values(fields).map(v => codec(v)),
+      meta: {
+        fields: Object.keys(fields).map(name => ({
+          name: { isSome: true, unwrap: () => codec(name) },
+          typeName: { isSome: true, unwrap: () => codec('Dummy') },
+        })),
+      },
+    },
+  } as unknown as SubstrateEvent);
 
 describe('asset allowances', () => {
   let db: MockDb;
@@ -41,6 +73,24 @@ describe('asset allowances', () => {
 
     await handleApproval(allowanceEvent('Approval', [OWNER, SPENDER, ASSET, '250']));
     expect(db['AssetAllowance'][id].amount).toBe(BigInt(250));
+  });
+
+  it('handleApproval resolves the same fields when the runtime names asset_id in snake_case', async () => {
+    await handleApproval(
+      namedAllowanceEvent('Approval', {
+        owner: OWNER,
+        spender: SPENDER,
+        asset_id: ASSET,
+        amount: '1000',
+      })
+    );
+
+    expect(db['AssetAllowance'][id]).toMatchObject({
+      assetId: ASSET,
+      ownerId: OWNER,
+      spenderId: SPENDER,
+      amount: BigInt(1000),
+    });
   });
 
   it('handleAllowanceSpent sets amount from remainingAllowance, not by subtraction', async () => {

--- a/tests/unit/mapAssetMetadata.test.ts
+++ b/tests/unit/mapAssetMetadata.test.ts
@@ -11,6 +11,7 @@ import {
   handleMetadataValueDeleted,
   handleRegisterAssetMetadataLocalType,
   handleSetAssetMetadataValue,
+  handleSetAssetMetadataValueDetails,
 } from '../../src/mappings/entities/assets/mapAssetMetadata';
 import { handleCreatedAssetTransfer } from '../../src/mappings/entities/assets/mapAsset';
 import { codec, MockDb, mockStore, storeSet, tupleEvent } from './helpers';
@@ -39,6 +40,33 @@ const setMetadataExtrinsic = (key: unknown) => ({
   extrinsic: {
     method: { section: 'asset', method: 'setAssetMetadata' },
     args: [codec(ASSET), codec(key)],
+  },
+});
+
+/** A `utility.batch*` extrinsic wrapping the given calls — `toHuman()` is all the resolver reads. */
+const batchExtrinsic = (
+  method: string,
+  calls: { section: string; method: string; args: Record<string, unknown> }[]
+) => ({
+  idx: 1,
+  extrinsic: {
+    method: { section: 'utility', method },
+    toHuman: () => ({ method: { args: { calls } } }),
+  },
+});
+
+const setMetadataCall = (assetId: string, key: unknown, method = 'setAssetMetadata') => ({
+  section: 'asset',
+  method,
+  args: { asset_id: assetId, key, value: 'ipfs://batched', detail: null },
+});
+
+/** A `multiSig.approve(multisig, proposalId, weight)` extrinsic. */
+const multiSigApproveExtrinsic = (multisig: string, proposalId: string) => ({
+  idx: 1,
+  extrinsic: {
+    method: { section: 'multiSig', method: 'approve' },
+    args: [codec(multisig), codec(proposalId)],
   },
 });
 
@@ -116,6 +144,191 @@ describe('asset metadata', () => {
       value: 'ipfs://new',
     });
     expect(storeSet().mock.calls.some(([entity]) => entity === 'IndexerAnomaly')).toBe(false);
+  });
+
+  it('recovers the key from a setAssetMetadata call batched in a utility.batchAll extrinsic', async () => {
+    await handleSetAssetMetadataValue(
+      metaEvent(
+        'SetAssetMetadataValue',
+        [codec('0xdid'), codec(ASSET), codec('blob:cf'), codec(null, { isEmpty: true })],
+        batchExtrinsic('batchAll', [
+          { section: 'asset', method: 'createAsset', args: {} },
+          setMetadataCall(ASSET, { Global: '5' }),
+        ])
+      )
+    );
+
+    expect(db['AssetMetadata'][`${ASSET}/Global/5`]).toMatchObject({
+      scope: 'Global',
+      keyId: '5',
+      value: 'blob:cf',
+    });
+    expect(storeSet().mock.calls.some(([entity]) => entity === 'IndexerAnomaly')).toBe(false);
+  });
+
+  it('matches the right call by ordinal (not first-match) when a batch sets metadata for two different assets', async () => {
+    const OTHER = '0xother00000000000000000000000000';
+    db['Asset'][OTHER] = { id: OTHER, type: 'EquityCommon' };
+
+    // one SetAssetMetadataValue for OTHER already fired earlier in the same extrinsic — the event
+    // under test is the batch's *second* metadata call, not its first
+    const priorEventForOther = siblingRecord(
+      'SetAssetMetadataValue',
+      [codec('0xdid'), codec(OTHER), codec('blob:other'), codec(null, { isEmpty: true })],
+      1
+    );
+
+    await handleSetAssetMetadataValue(
+      metaEvent(
+        'SetAssetMetadataValue',
+        [codec('0xdid'), codec(ASSET), codec('blob:mine'), codec(null, { isEmpty: true })],
+        batchExtrinsic('batch', [
+          setMetadataCall(OTHER, { Global: '9' }),
+          setMetadataCall(ASSET, { Global: '5' }),
+        ]),
+        [priorEventForOther]
+      )
+    );
+
+    expect(db['AssetMetadata'][`${ASSET}/Global/5`]).toMatchObject({ value: 'blob:mine' });
+    expect(db['AssetMetadata'][`${OTHER}/Global/9`]).toBeUndefined();
+  });
+
+  it('matches the right call by ordinal when a batch sets two different keys on the same asset (asset_id alone cannot disambiguate)', async () => {
+    const priorEventForFirstKey = siblingRecord(
+      'SetAssetMetadataValue',
+      [codec('0xdid'), codec(ASSET), codec('blob:first'), codec(null, { isEmpty: true })],
+      1
+    );
+
+    await handleSetAssetMetadataValue(
+      metaEvent(
+        'SetAssetMetadataValue',
+        [codec('0xdid'), codec(ASSET), codec('blob:second'), codec(null, { isEmpty: true })],
+        batchExtrinsic('batchAll', [
+          setMetadataCall(ASSET, { Global: '1' }),
+          setMetadataCall(ASSET, { Global: '2' }),
+        ]),
+        [priorEventForFirstKey]
+      )
+    );
+
+    expect(db['AssetMetadata'][`${ASSET}/Global/2`]).toMatchObject({ value: 'blob:second' });
+    expect(db['AssetMetadata'][`${ASSET}/Global/1`]).toBeUndefined();
+  });
+
+  it('resolves a setAssetMetadataDetails call batched alongside a setAssetMetadata call', async () => {
+    db['AssetMetadata'] = {
+      [`${ASSET}/Global/5`]: {
+        id: `${ASSET}/Global/5`,
+        assetId: ASSET,
+        scope: 'Global',
+        keyId: '5',
+      },
+    };
+    const priorEventForValue = siblingRecord(
+      'SetAssetMetadataValue',
+      [codec('0xdid'), codec(ASSET), codec('blob:cf'), codec(null, { isEmpty: true })],
+      1
+    );
+
+    await handleSetAssetMetadataValueDetails(
+      metaEvent(
+        'SetAssetMetadataValueDetails',
+        [codec('0xdid'), codec(ASSET), codec({ expire: null, lockStatus: 'Locked' })],
+        batchExtrinsic('batchAll', [
+          setMetadataCall(ASSET, { Global: '5' }),
+          setMetadataCall(ASSET, { Global: '5' }, 'setAssetMetadataDetails'),
+        ]),
+        [priorEventForValue]
+      )
+    );
+
+    expect(db['AssetMetadata'][`${ASSET}/Global/5`]).toMatchObject({ isLocked: true });
+  });
+
+  it('recovers the key with the comma toHuman() puts in a 4+ digit key id', async () => {
+    await handleSetAssetMetadataValue(
+      metaEvent(
+        'SetAssetMetadataValue',
+        [codec('0xdid'), codec(ASSET), codec('blob:big'), codec(null, { isEmpty: true })],
+        batchExtrinsic('batchAll', [setMetadataCall(ASSET, { Global: '1,234' })])
+      )
+    );
+
+    expect(db['AssetMetadata'][`${ASSET}/Global/1234`]).toMatchObject({ value: 'blob:big' });
+  });
+
+  it('recovers the key from a proposal executed via multiSig.approve', async () => {
+    db['MultiSigProposal'] = {
+      '5MultiSig/16': {
+        id: '5MultiSig/16',
+        params: {
+          isBatch: false,
+          isBridge: false,
+          proposals: [
+            {
+              module: 'asset',
+              call: 'set_asset_metadata',
+              args: JSON.stringify({ asset_id: ASSET, key: { Global: '5' }, value: 'ipfs://cid' }),
+            },
+          ],
+        },
+      },
+    };
+
+    await handleSetAssetMetadataValue(
+      metaEvent(
+        'SetAssetMetadataValue',
+        [codec('0xdid'), codec(ASSET), codec('ipfs://cid'), codec(null, { isEmpty: true })],
+        multiSigApproveExtrinsic('5MultiSig', '16')
+      )
+    );
+
+    expect(db['AssetMetadata'][`${ASSET}/Global/5`]).toMatchObject({
+      scope: 'Global',
+      keyId: '5',
+      value: 'ipfs://cid',
+    });
+  });
+
+  it('falls through to an anomaly when multiSig.approve references a proposal that was never indexed', async () => {
+    await handleSetAssetMetadataValue(
+      metaEvent(
+        'SetAssetMetadataValue',
+        [codec('0xdid'), codec(ASSET), codec('x'), codec(null, { isEmpty: true })],
+        multiSigApproveExtrinsic('5Unknown', '99')
+      )
+    );
+
+    expect(db['AssetMetadata']).toBeUndefined();
+    expect(storeSet().mock.calls.some(([entity]) => entity === 'IndexerAnomaly')).toBe(true);
+  });
+
+  it('falls through to an anomaly when the approved proposal carries no metadata call', async () => {
+    db['MultiSigProposal'] = {
+      '5MultiSig/17': {
+        id: '5MultiSig/17',
+        params: {
+          isBatch: false,
+          isBridge: false,
+          proposals: [
+            { module: 'asset', call: 'create_asset', args: JSON.stringify({ asset_name: 'X' }) },
+          ],
+        },
+      },
+    };
+
+    await handleSetAssetMetadataValue(
+      metaEvent(
+        'SetAssetMetadataValue',
+        [codec('0xdid'), codec(ASSET), codec('x'), codec(null, { isEmpty: true })],
+        multiSigApproveExtrinsic('5MultiSig', '17')
+      )
+    );
+
+    expect(db['AssetMetadata']).toBeUndefined();
+    expect(storeSet().mock.calls.some(([entity]) => entity === 'IndexerAnomaly')).toBe(true);
   });
 
   it('records an anomaly and writes nothing only when neither the extrinsic nor a sibling resolves the key', async () => {


### PR DESCRIPTION
## What

Three fixes found by resync-testing `redesign/07-schema-invariants` from genesis against
testnet — the first full resync of anything past Phase 4, so the first time several code paths
ever ran against real chain data. Branched off `redesign/07-schema-invariants`; base this PR on
it, not `master`.

### 1. `SetAssetMetadataValue` couldn't resolve its key through a batch or multisig proposal

`resolveMetadataKey` only inspected the outer, signed extrinsic. A `setAssetMetadata(Details)`
call reached via `utility.batch*` (the common "create an asset and set its metadata inline"
shape) or executed by `multiSig.approve` of a previously-created proposal never resolved — the
row was silently dropped with a `MissingReferencedEntity` anomaly instead of being written.

Root-caused against 12 real occurrences on testnet (specs `7002000`/`7004000`/`7004001`/
`8000000`). Both new paths pick their call by ordinal position among same-extrinsic
`SetAssetMetadataValue(Details)` siblings (not by `asset_id` alone — a batch/proposal can set more
than one key, including twice for the same asset) and verify against the already-decoded
`assetId` as a consistency guard. `parseMetadataKey` also strips the thousands separators
`toHuman()` puts in a `u64` (`"1,234"`), which would otherwise split a key's rows depending on
which path resolved it. Both of those were caught in an Opus review of the first version of this
fix, along with several test-coverage gaps — see the commit body for the full review trail.

Pre-existing since Phase 5 (`redesign/05-holdings-nfts`, `6149410`); not introduced by phase 7.

### 2. A later v8 runtime names an event's fields in snake_case, crashing the indexer

Found live, mid-resync, as a genuine crash loop (not a candidate item — this blocked the resync
from ever completing). `asset.Approval`'s metadata names its fields in Substrate's idiomatic Rust
snake_case (`asset_id`) on a later v8 testnet spec, not the camelCase (`assetId`) every shape
table and handler in this codebase reads. The decode layer's own doc comment asserted Polymesh
pallets are tuple-style (no field names) at every spec version — true until this runtime — so
there was no shape-table fallback once metadata named a field at all, and nothing caught the
resulting `FieldNotFound` at the handler call site.

Fixed at the root in `metadataFieldNames`, not as a one-event patch: normalise a metadata field
name to camelCase only when it contains an underscore, a no-op for the (previously universal)
already-camelCase case. Deployed directly to the resync server mid-run (code-only change, no
schema drop) to unblock it; confirmed it sailed through the stuck block cleanly.

### 3. A17: lazily-discovered accounts got approximate provenance

`getOrCreateAccount` defaulted `createdEventId` to the block's first event
(`${blockId}/0000000000`) for every account discovered while resolving an asset transfer's
from/to holder — accepted as a bounded phase-7 follow-up rather than an in-phase cascade (see
`docs/implementation/13-entity-provenance.md`).

Threaded the real `blockEventId` through the whole asset-holder resolution chain
(`rawAssetHolderToAssetHolder` → `extractAssetHolder` → `meshAssetHolderToAssetHolder` →
`getOrCreateAccount`) from every real call site: asset transfers/allowances, NFT transfers,
settlement legs and funds transfers. The portfolio-only paths never call `getOrCreateAccount` and
needed no change. A caller with no event to give still gets the old default.

## Testing

- `yarn codegen && yarn typecheck && yarn lint && yarn test:unit && yarn check-handlers && yarn build`
  — all green throughout (final: 0 type errors, 0 lint warnings, **512/512 unit tests**).
- Verified against a full genesis-to-tip testnet resync (`redesign/07-schema-invariants` +
  these fixes): reached chain head cleanly. Final `indexer_anomalies` table has exactly the 12
  rows item 1 explains — nothing else — and **zero** `BalanceReconciliationDrift` rows (better
  than expected; the phase-7 reconcile-hygiene fix left no drift at all across the whole run).
